### PR TITLE
Update $type filter values to match GeoJSON/VectorTile spec

### DIFF
--- a/reference/v3.json
+++ b/reference/v3.json
@@ -435,12 +435,10 @@
     "$type": {
       "type": "enum",
       "values": [
-        "any",
-        "point",
-        "line",
-        "polygon"
+        "Point",
+        "LineString",
+        "Polygon"
       ],
-      "default": "any",
       "doc": "Geometry type that features must match."
     },
     "*": [


### PR DESCRIPTION
Fixes #52. Also, I removed `any` value and default since the default is not specifying $type at all — it's a filter after all.

Related: https://github.com/mapbox/vector-tile-js/pull/9
