### PR TITLE
merge icon and text render types into symbol type

### DIFF
--- a/reference/v3.json
+++ b/reference/v3.json
@@ -244,6 +244,11 @@
         "default": false,
         "doc": "If true, the icon won't affect placement of other icons and text."
     },
+    "icon-allow-without-text": {
+        "type": "boolean",
+        "default": false,
+        "doc": "The icon can only be placed without or before text if this is true, or if the layer has no text."
+    },
     "icon-rotation-alignment": {
       "type": "enum",
       "values": [
@@ -409,6 +414,11 @@
       "type": "boolean",
       "default": false,
       "doc": "If true, the text won't affect placement of other icons and labels."
+    },
+    "text-allow-without-icon": {
+        "type": "boolean",
+        "default": false,
+        "doc": "The text can only be placed without or before the icon if this is true, or if the layer has no icon."
     }
   },
   "render_composite": {


### PR DESCRIPTION
Text and icon render types are merged into the symbol render type. With the types combined, we can place points + text together which means better placement and support for shields. #67.

A layer with the symbol render type can specify both text and icon properties. Some properties, those prefixed with symbol-, affect both.
- `symbol-placement` controls whether placement happens at a point or along a line
- `symbol-min-distance` replaces `icon-spacing` and `text-min-distance`
- `symbol-allow-overlap` and `symbol-ignore-placement` replace the text- and icon- versions
- `text-upright` and `icon-upright` control whether the symbols can get flipped
- `symbol-rotation-alignment` controls whether the symbol rotates with the map, replacing `text-path` and `icon-rotate-anchor`

If this looks ok I'll update the conversion script.

@mourner @kkaefer @yhahn 
