### PR TITLE
Promote glyphs to a top level element

### DIFF
--- a/reference/v3.json
+++ b/reference/v3.json
@@ -31,7 +31,7 @@
     "glyphs": {
       "type": "string",
       "doc": "A URL template for loading signed-distance-field glyph sets in PBF format. Valid tokens are {{fontstack}} and {{range}}."
-    },
+    }
   },
   "sprite": [{
     "type": "string",


### PR DESCRIPTION
Currently, glyphs are specified in a source, but this doesn't make much sense, since multiple sources can use the same glyph endpoint. If we ever chose to support multiple glyph endpoints in a single stylesheet, we can revisit expanding this property later.
