### PR TITLE
Remove Background Bucket

### DIFF
--- a/reference/v3.json
+++ b/reference/v3.json
@@ -151,7 +151,7 @@
     "render_icon",
     "render_text",
     "render_composite",
-    "render_raster",
+    "render_raster"
   ],
   "render_fill": {
     "type": {


### PR DESCRIPTION
We don't need to specify the render type of a background layer, since we do matching for background bucket by layer name anyway.
