### PR TITLE
[not sure if ready] V4 spec fixes

### DIFF
--- a/reference/v4.json
+++ b/reference/v4.json
@@ -657,7 +657,7 @@
     },
     "fill-translate": {
       "type": "array",
-      "value": ["number", "function"],
+      "value": "number",
       "length": 2,
       "default": [
         0,
@@ -703,7 +703,7 @@
     },
     "line-translate": {
       "type": "array",
-      "value": ["number", "function"],
+      "value": "number",
       "length": 2,
       "default": [
         0,
@@ -741,7 +741,7 @@
     },
     "line-dasharray": {
       "type": "array",
-      "value": ["number", "function"],
+      "value": "number",
       "length": 2,
       "default": [
         1,
@@ -817,7 +817,7 @@
     },
     "icon-translate": {
       "type": "array",
-      "value": ["number", "function"],
+      "value": "number",
       "length": 2,
       "default": [
         0,
@@ -882,7 +882,7 @@
     },
     "text-translate": {
       "type": "array",
-      "value": ["number", "function"],
+      "value": "number",
       "length": 2,
       "default": [
         0,
@@ -926,7 +926,7 @@
     },
     "raster-brightness": {
       "type": "array",
-      "value": ["number", "function"],
+      "value": "number",
       "length": 2,
       "default": [
         0,

--- a/test.js
+++ b/test.js
@@ -46,7 +46,13 @@ function validSchema(k, t, obj, ref) {
 
         // schema type is array, it must have 'value' and it must be a type.
         if (obj.value !== undefined)
-            t.ok(types.indexOf(obj.value) !== -1, k + '.value (' + obj.value + ')');
+            if (Array.isArray(obj.value)) {
+                obj.value.every(function(i) {
+                    t.ok(types.indexOf(i) !== -1, k + '.value (' + i + ')');
+                });
+            } else {
+                t.ok(types.indexOf(obj.value) !== -1, k + '.value (' + obj.value + ')');
+            }
 
         // schema key type checks
         if (obj.doc !== undefined)
@@ -71,4 +77,3 @@ function validSchema(k, t, obj, ref) {
         t.ok(false, 'Invalid: ' + k);
     }
 }
-


### PR DESCRIPTION
The following changes make a migrated 4sq v4 map validate completely. 
#### [Add `filter_comparison` as an option within `filter-value`](https://github.com/mapbox/mapbox-gl-style-spec/blob/ab690bb50563e9dc64183dda12d8e8fbe8eba22a/reference/v4.json#L531-L533):

```
  "filter_value": [
    {
      "type": "filter_primitive"
    },
    {
      "type": "filter_comparison"
    },
    {
      "type": "array",
      "value": "filter_primitive"
    }
```

   This fixes issues previously caught by the validator such as [this](https://github.com/mapbox/mapbox-gl-custom-styles/blob/4sq/4sq/style-v4.json#L2417):

```
    "filter": {
      "scalerank": 1,
      "type": "Rail Station",
      "network": { "!=": null },
      "$type": "Point"
    },
```

   that previously caused the validator to spit out

```
line null, layers[100].filter.network.!=: string expected, object found
line null, layers[100].filter.network.!=: number expected, object found
line null, layers[100].filter.network.!=: boolean expected, object found
line null, layers[100].filter.network.!=: array expected, object found
line 2417, layers[100].filter.network: string expected, object found
line 2417, layers[100].filter.network: number expected, object found
line 2417, layers[100].filter.network: boolean expected, object found
line 2417, layers[100].filter.network: array expected, object found
line 2417, layers[100].filter: array expected, object found
```

   as `filter_value` expected only `filter_primitive`s (string, number, boolean) or arrays.
#### [`function_stop` can take number or color](https://github.com/mapbox/mapbox-gl-style-spec/blob/ab690bb50563e9dc64183dda12d8e8fbe8eba22a/reference/v4.json#L611):

```
  "function_stop": {
    "type": "array",
    "value": ["number", "color"],
    "length": 2,
    "doc": "Zoom level and value pair."
  },
```

   This fixes issues that were happening [here](https://github.com/mapbox/mapbox-gl-custom-styles/blob/4sq/4sq/style-v4.json#L43-L46):

```
    "@motorway-main-text": {
      "fn": "stops",
      "stops": [[16.75, "#615952"], [17, "#746b62"], [17.75, "#746b62"], [18, "#615952"]]
    },
```

   where fn stops didn't validate hex strings.
#### [Re-added base as fn value](https://github.com/mapbox/mapbox-gl-style-spec/blob/ab690bb50563e9dc64183dda12d8e8fbe8eba22a/reference/v4.json#L602-L606)

   This had been removed since v2 but decided to re-add per chat.
#### [Allow several properties to take arrays of functions](https://github.com/mapbox/mapbox-gl-style-spec/blob/ab690bb50563e9dc64183dda12d8e8fbe8eba22a/reference/v4.json#L658-L661).

   These include `{fill,line,text,icon}-translate`, `line-dasharray`, and `raster-brightness`, as discussed in #85 and now look like

```
    "fill-translate": {
      "type": "array",
      "value": ["number", "function"],
      "length": 2,  ...
```

...anything objectionable?
