### PR TITLE
remove -enabled style properties

### DIFF
--- a/reference/v4.json
+++ b/reference/v4.json
@@ -627,12 +627,6 @@
     "class_background"
   ],
   "class_fill": {
-    "fill-enabled": {
-      "type": "boolean",
-      "function": true,
-      "default": true,
-      "transition": true
-    },
     "fill-antialias": {
       "type": "boolean",
       "default": true,
@@ -685,12 +679,6 @@
     }
   },
   "class_line": {
-    "line-enabled": {
-      "type": "boolean",
-      "function": true,
-      "default": true,
-      "transition": true
-    },
     "line-opacity": {
       "type": "number",
       "function": true,
@@ -762,12 +750,6 @@
     }
   },
   "class_symbol": {
-    "icon-enabled": {
-      "type": "boolean",
-      "default": true,
-      "function": true,
-      "transition": true
-    },
     "icon-opacity": {
       "type": "number",
       "default": 1,
@@ -832,12 +814,6 @@
       "function": true,
       "transition": true
     },
-    "text-enabled": {
-      "type": "boolean",
-      "default": true,
-      "function": true,
-      "transition": true
-    },
     "text-opacity": {
       "type": "number",
       "default": 1,
@@ -899,12 +875,6 @@
     }
   },
   "class_composite": {
-    "composite-enabled": {
-      "type": "boolean",
-      "default": true,
-      "function": true,
-      "transition": true
-    },
     "composite-opacity": {
       "type": "number",
       "default": 1,
@@ -913,12 +883,6 @@
     }
   },
   "class_raster": {
-    "raster-enabled": {
-      "type": "boolean",
-      "default": true,
-      "function": true,
-      "transition": true
-    },
     "raster-opacity": {
       "type": "number",
       "default": 1,


### PR DESCRIPTION
I think we should remove the `*-enabled` properties for all render types. Layers can be hidden with `"opacity": 0`. We also have min-zoom and max-zoom for easily setting when a layer first appears. This property is not currently implemented in -js and I don't think it is used in any of the current styles.

@kapadia @mourner @nickidlugash 
