### PR TITLE
Replace {{tokens}} with {tokens} in docs

### DIFF
--- a/docs/_generate/index.html
+++ b/docs/_generate/index.html
@@ -45,7 +45,7 @@ navigation:
     id: transition
   - title: Values
     id: values
-    subnav: 
+    subnav:
     - title: Color
       id: color
     - title: Enum
@@ -111,7 +111,7 @@ navigation:
 
       <p>The Mapbox GL style is an object that defines what data to draw, the order to draw it in, and how to style the data when drawing it. The <a href='http://json.org'>JSON</a> structure follows the renderer implementation very closely. It provides the basic building blocks out of which more complex styles can be built.</p>
 
-      <p class='space-bottom4 quiet small'>Key: 
+      <p class='space-bottom4 quiet small'>Key:
         <span class='icon levels quiet micro space-right inline' title='Supports function values'>supports function values</span>
         <span class='icon opacity quiet micro space-right inline' title='Transitionable'>transitionable</span>
       </p>
@@ -186,9 +186,9 @@ navigation:
   <div class='code pad1 quiet'>}</div>
 </div>
 
-    <% 
+    <%
     var render_types = ['fill', 'line', 'symbol'];
-    var class_types = ['fill', 'line', 'symbol', 'background', 'composite', 'raster']; 
+    var class_types = ['fill', 'line', 'symbol', 'background', 'composite', 'raster'];
     %>
 
     <div id='render' class='pad2'>
@@ -266,7 +266,7 @@ navigation:
         <p class='small'>A string is basically just text. In the case of Mapbox GL, you're going to put it in quotes. Strings can be anything, though pay attention to the case of <code>text-name</code> - it actually will refer to features, which you refer to by putting them in curly braces, as seen in the example below.</p>
 {% highlight json %}
 {
-  "text-name": "{{MY_FIELD}}"
+  "text-name": "{MY_FIELD}"
 }
 {% endhighlight %}
       </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -45,7 +45,7 @@ navigation:
     id: transition
   - title: Values
     id: values
-    subnav: 
+    subnav:
     - title: Color
       id: color
     - title: Enum
@@ -111,7 +111,7 @@ navigation:
 
       <p>The Mapbox GL style is an object that defines what data to draw, the order to draw it in, and how to style the data when drawing it. The <a href='http://json.org'>JSON</a> structure follows the renderer implementation very closely. It provides the basic building blocks out of which more complex styles can be built.</p>
 
-      <p class='space-bottom4 quiet small'>Key: 
+      <p class='space-bottom4 quiet small'>Key:
         <span class='icon levels quiet micro space-right inline' title='Supports function values'>supports function values</span>
         <span class='icon opacity quiet micro space-right inline' title='Transitionable'>transitionable</span>
       </p>
@@ -145,12 +145,12 @@ navigation:
 },</div>
     <p class='small quiet'>Data source specifications for layers to pull from.</p>
     <div class='pad1 fill-darken0 round'>
-    
+
     <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>type</span>
-    
-    
+
+
   </div>
   <div class='small pad2x'>
     <em class='inline quiet'>
@@ -160,112 +160,112 @@ navigation:
     <span class='space-right quiet'>
       <em>One of</em> <var>vector</var>, <var>raster</var>, <var>geojson</var>, <var>video</var>.
     </span>
-    
+
   </div>
-  
+
   <div class='small pad2x'>The data type of the source.</div>
-  
+
 </div>
 
-    
+
     <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>url</span>
-    
-    
+
+
   </div>
   <div class='small pad2x'>
     <em class='inline quiet'>
       Required
       <a href='#string'>string</a>.
     </em>
-    
-    
+
+
   </div>
-  
+
   <div class='small pad2x'>A URL, or URL template to retrive the source data.</div>
-  
+
 </div>
 
-    
+
     <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>tileSize</span>
-    
-    
+
+
   </div>
   <div class='small pad2x'>
     <em class='inline quiet'>
       Optional
       <a href='#number'>number</a>.
     </em>
-    
+
     <span class='space-right quiet'>
       <em>Defaults to </em> <var>512</var>.
     </span>
   </div>
-  
+
 </div>
 
-    
+
     <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>minZoom</span>
-    
-    
+
+
   </div>
   <div class='small pad2x'>
     <em class='inline quiet'>
       Optional
       <a href='#number'>number</a>.
     </em>
-    
-    
+
+
   </div>
-  
+
 </div>
 
-    
+
     <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>maxZoom</span>
-    
-    
+
+
   </div>
   <div class='small pad2x'>
     <em class='inline quiet'>
       Optional
       <a href='#number'>number</a>.
     </em>
-    
+
     <span class='space-right quiet'>
       <em>Defaults to </em> <var>22</var>.
     </span>
   </div>
-  
+
 </div>
 
-    
+
     <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>*</span>
-    
-    
+
+
   </div>
   <div class='small pad2x'>
     <em class='inline quiet'>
       Optional
-      
+
     </em>
-    
-    
+
+
   </div>
-  
+
   <div class='small pad2x'>Other keys to configure the data source.</div>
-  
+
 </div>
 
-    
+
     </div>
   </div>
   <div id='layers' class='pad2 keyline-bottom'>
@@ -284,32 +284,32 @@ navigation:
 ],</div>
     <p class='small quiet'>A an array of layers. The order of layers coincides with the order they will be drawn.</p>
     <div class='pad1 fill-darken0 round'>
-      
+
       <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>id</span>
-    
-    
+
+
   </div>
   <div class='small pad2x'>
     <em class='inline quiet'>
       Optional
       <a href='#string'>string</a>.
     </em>
-    
-    
+
+
   </div>
-  
+
   <div class='small pad2x'>Unique layer name.</div>
-  
+
 </div>
 
-      
+
       <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>type</span>
-    
-    
+
+
   </div>
   <div class='small pad2x'>
     <em class='inline quiet'>
@@ -319,232 +319,232 @@ navigation:
     <span class='space-right quiet'>
       <em>One of</em> <var>fill</var>, <var>line</var>, <var>symbol</var>, <var>composite</var>, <var>raster</var>, <var>background</var>.
     </span>
-    
+
   </div>
-  
+
   <div class='small pad2x'>Rendering type of this layer.</div>
-  
+
 </div>
 
-      
+
       <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>ref</span>
-    
-    
+
+
   </div>
   <div class='small pad2x'>
     <em class='inline quiet'>
       Optional
       <a href='#string'>string</a>.
     </em>
-    
-    
+
+
   </div>
-  
+
   <div class='small pad2x'>References another layer to copy `source`, `source_layer`, `filter`, and `render` properties from. This allows the layers to share processing and be more efficient.</div>
-  
+
 </div>
 
-      
+
       <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>source</span>
-    
-    
+
+
   </div>
   <div class='small pad2x'>
     <em class='inline quiet'>
       Optional
       <a href='#string'>string</a>.
     </em>
-    
-    
+
+
   </div>
-  
+
   <div class='small pad2x'>Name of a source description to be used for this layer. Required if this is not a composite layer.</div>
-  
+
 </div>
 
-      
+
       <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>source-layer</span>
-    
-    
+
+
   </div>
   <div class='small pad2x'>
     <em class='inline quiet'>
       Optional
       <a href='#string'>string</a>.
     </em>
-    
-    
+
+
   </div>
-  
+
   <div class='small pad2x'>Layer to use from a vector tile source. Required if this is not a composite layer, and if the source supports multiple layers.</div>
-  
+
 </div>
 
-      
+
       <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>min-zoom</span>
-    
-    
+
+
   </div>
   <div class='small pad2x'>
     <em class='inline quiet'>
       Optional
       <a href='#number'>number</a>.
     </em>
-    
-    
+
+
   </div>
-  
+
   <div class='small pad2x'>The minimum zoom level on which the layer gets parsed and appears on.</div>
-  
+
 </div>
 
-      
+
       <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>max-zoom</span>
-    
-    
+
+
   </div>
   <div class='small pad2x'>
     <em class='inline quiet'>
       Optional
       <a href='#number'>number</a>.
     </em>
-    
-    
+
+
   </div>
-  
+
   <div class='small pad2x'>The maximum zoom level on which the layer gets parsed and appears on.</div>
-  
+
 </div>
 
-      
+
       <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>render</span>
-    
-    
+
+
   </div>
   <div class='small pad2x'>
     <em class='inline quiet'>
       Optional
       <a href='#render'>render</a>.
     </em>
-    
-    
+
+
   </div>
-  
+
   <div class='small pad2x'>Symbolizer type that should be used to visualize this layer. If unspecified or null, this layer is not treated as a symbolizer and only exists to have properties inherited to other layers using ref.</div>
-  
+
 </div>
 
-      
+
       <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>filter</span>
-    
-    
+
+
   </div>
   <div class='small pad2x'>
     <em class='inline quiet'>
       Optional
       <a href='#filter'>filter</a>.
     </em>
-    
-    
+
+
   </div>
-  
+
   <div class='small pad2x'>Array or object of filters or expressions.</div>
-  
+
 </div>
 
-      
+
       <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>layers</span>
-    
-    
+
+
   </div>
   <div class='small pad2x'>
     <em class='inline quiet'>
       Optional
       <a href='#array'>array</a>.
     </em>
-    
-    
+
+
   </div>
-  
+
   <div class='small pad2x'>If 'type' is 'composite', the child layers are composited together onto the previous level layer level.</div>
-  
+
 </div>
 
-      
+
       <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>rasterize</span>
-    
-    
+
+
   </div>
   <div class='small pad2x'>
     <em class='inline quiet'>
       Optional
       <a href='#rasterize'>rasterize</a>.
     </em>
-    
-    
+
+
   </div>
-  
+
 </div>
 
-      
+
       <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>style</span>
-    
-    
+
+
   </div>
   <div class='small pad2x'>
     <em class='inline quiet'>
       Optional
       <a href='#class'>class</a>.
     </em>
-    
-    
+
+
   </div>
-  
+
   <div class='small pad2x'>Default style properties for this layer.</div>
-  
+
 </div>
 
-      
+
       <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>style.*</span>
-    
-    
+
+
   </div>
   <div class='small pad2x'>
     <em class='inline quiet'>
       Optional
       <a href='#class'>class</a>.
     </em>
-    
-    
+
+
   </div>
-  
+
   <div class='small pad2x'>Override style properties for this layer. The class name is the part after the first dot.</div>
-  
+
 </div>
 
-      
+
     </div>
   </div>
   <div class='pad2 keyline-bottom' id='transition'>
@@ -554,49 +554,49 @@ navigation:
 },</div>
     <p class='small quiet'>@TODO</p>
     <div class='pad1 fill-darken0 round'>
-    
+
     <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>duration</span>
-    
-    
+
+
   </div>
   <div class='small pad2x'>
     <em class='inline quiet'>
       Optional
       <a href='#number'>number</a>.
     </em>
-    
-    
+
+
   </div>
-  
+
 </div>
 
-    
+
     <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>delay</span>
-    
-    
+
+
   </div>
   <div class='small pad2x'>
     <em class='inline quiet'>
       Optional
       <a href='#number'>number</a>.
     </em>
-    
-    
+
+
   </div>
-  
+
 </div>
 
-    
+
     </div>
   </div>
   <div class='code pad1 quiet'>}</div>
 </div>
 
-    
+
 
     <div id='render' class='pad2'>
       <h2><a href='#render' title='link to render'>Render</a></h2>
@@ -604,15 +604,15 @@ navigation:
     </div>
 
     <div class='round space-bottom4 fill-white keyline-all'>
-      
+
       <div id='render_fill' class='pad2 keyline-bottom'>
         <h3 class='space-bottom1'><a href='#render_fill' title='link to render: fill'>Render: fill</a></h3>
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>fill-winding</span>
-    
-    
+
+
   </div>
   <div class='small pad2x'>
     <em class='inline quiet'>
@@ -626,20 +626,20 @@ navigation:
       <em>Defaults to </em> <var>non-zero</var>.
     </span>
   </div>
-  
+
 </div>
 
-        
+
       </div>
-      
+
       <div id='render_line' class='pad2 keyline-bottom'>
         <h3 class='space-bottom1'><a href='#render_line' title='link to render: line'>Render: line</a></h3>
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>line-cap</span>
-    
-    
+
+
   </div>
   <div class='small pad2x'>
     <em class='inline quiet'>
@@ -653,17 +653,17 @@ navigation:
       <em>Defaults to </em> <var>butt</var>.
     </span>
   </div>
-  
+
   <div class='small pad2x'>The display of line endings.</div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>line-join</span>
-    
-    
+
+
   </div>
   <div class='small pad2x'>
     <em class='inline quiet'>
@@ -677,66 +677,66 @@ navigation:
       <em>Defaults to </em> <var>miter</var>.
     </span>
   </div>
-  
+
   <div class='small pad2x'>The display of lines when joining.</div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>line-miter-limit</span>
-    
-    
+
+
   </div>
   <div class='small pad2x'>
     <em class='inline quiet'>
       Optional
       <a href='#number'>number</a>.
     </em>
-    
+
     <span class='space-right quiet'>
       <em>Defaults to </em> <var>2</var>.
     </span>
   </div>
-  
+
   <div class='small pad2x'>Used to automatically convert miter joins to bevel joins for sharp angles.</div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>line-round-limit</span>
-    
-    
+
+
   </div>
   <div class='small pad2x'>
     <em class='inline quiet'>
       Optional
       <a href='#number'>number</a>.
     </em>
-    
+
     <span class='space-right quiet'>
       <em>Defaults to </em> <var>1</var>.
     </span>
   </div>
-  
+
   <div class='small pad2x'>Used to automatically convert round joins to miter joins for shallow angles.</div>
-  
+
 </div>
 
-        
+
       </div>
-      
+
       <div id='render_symbol' class='pad2 '>
         <h3 class='space-bottom1'><a href='#render_symbol' title='link to render: symbol'>Render: symbol</a></h3>
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>symbol-placement</span>
-    
-    
+
+
   </div>
   <div class='small pad2x'>
     <em class='inline quiet'>
@@ -746,99 +746,99 @@ navigation:
     <span class='space-right quiet'>
       <em>One of</em> <var>point</var>, <var>line</var>.
     </span>
-    
+
   </div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>symbol-min-distance</span>
-    
-    
+
+
   </div>
   <div class='small pad2x'>
     <em class='inline quiet'>
       Optional
       <a href='#number'>number</a>.
     </em>
-    
+
     <span class='space-right quiet'>
       <em>Defaults to </em> <var>250</var>.
     </span>
   </div>
-  
+
   <div class='small pad2x'>Minimum distance between two symbol anchors (px)</div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>icon-allow-overlap</span>
-    
-    
+
+
   </div>
   <div class='small pad2x'>
     <em class='inline quiet'>
       Optional
       <a href='#boolean'>boolean</a>.
     </em>
-    
-    
+
+
   </div>
-  
+
   <div class='small pad2x'>If true, the icon will be visible even if it collides with other icons and text.</div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>icon-ignore-placement</span>
-    
-    
+
+
   </div>
   <div class='small pad2x'>
     <em class='inline quiet'>
       Optional
       <a href='#boolean'>boolean</a>.
     </em>
-    
-    
+
+
   </div>
-  
+
   <div class='small pad2x'>If true, the icon won't affect placement of other icons and text.</div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>icon-optional</span>
-    
-    
+
+
   </div>
   <div class='small pad2x'>
     <em class='inline quiet'>
       Optional
       <a href='#boolean'>boolean</a>.
     </em>
-    
-    
+
+
   </div>
-  
+
   <div class='small pad2x'>If true, text can be shown without its corresponding icon.</div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>icon-rotation-alignment</span>
-    
-    
+
+
   </div>
   <div class='small pad2x'>
     <em class='inline quiet'>
@@ -852,96 +852,96 @@ navigation:
       <em>Defaults to </em> <var>viewport</var>.
     </span>
   </div>
-  
+
   <div class='small pad2x'>Orientation of icon when map is rotated</div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>icon-max-size</span>
-    
-    
+
+
   </div>
   <div class='small pad2x'>
     <em class='inline quiet'>
       Optional
       <a href='#number'>number</a>.
     </em>
-    
+
     <span class='space-right quiet'>
       <em>Defaults to </em> <var>1</var>.
     </span>
   </div>
-  
+
   <div class='small pad2x'>The maximum amount to scale the icon by.</div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>icon-image</span>
-    
-    
+
+
   </div>
   <div class='small pad2x'>
     <em class='inline quiet'>
       Optional
       <a href='#string'>string</a>.
     </em>
-    
-    
+
+
   </div>
-  
+
   <div class='small pad2x'>A string with {{tokens}} replaced, referencing the data property to pull from.</div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>icon-padding</span>
-    
-    
+
+
   </div>
   <div class='small pad2x'>
     <em class='inline quiet'>
       Optional
       <a href='#number'>number</a>.
     </em>
-    
+
     <span class='space-right quiet'>
       <em>Defaults to </em> <var>2</var>.
     </span>
   </div>
-  
+
   <div class='small pad2x'>Padding value around icon bounding box to avoid icon collisions (px).</div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>icon-keep-upright</span>
-    
-    
+
+
   </div>
   <div class='small pad2x'>
     <em class='inline quiet'>
       Optional
       <a href='#boolean'>boolean</a>.
     </em>
-    
-    
+
+
   </div>
-  
+
   <div class='small pad2x'>If true, the icon may be flipped to prevent it from being rendered upside-down</div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>icon-offset</span>
@@ -953,20 +953,20 @@ navigation:
       Optional
       <a href='#array'>array</a>.
     </em>
-    
+
     <span class='space-right quiet'>
       <em>Defaults to </em> <var>0,0</var>.
     </span>
   </div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>icon-translate-anchor</span>
-    
-    
+
+
   </div>
   <div class='small pad2x'>
     <em class='inline quiet'>
@@ -980,15 +980,15 @@ navigation:
       <em>Defaults to </em> <var>map</var>.
     </span>
   </div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>text-rotation-alignment</span>
-    
-    
+
+
   </div>
   <div class='small pad2x'>
     <em class='inline quiet'>
@@ -1002,143 +1002,143 @@ navigation:
       <em>Defaults to </em> <var>viewport</var>.
     </span>
   </div>
-  
+
   <div class='small pad2x'>Orientation of icon or text when map is rotated</div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>text-field</span>
-    
-    
+
+
   </div>
   <div class='small pad2x'>
     <em class='inline quiet'>
       Optional
       <a href='#string'>string</a>.
     </em>
-    
-    
+
+
   </div>
-  
+
   <div class='small pad2x'>Value to use for a text label. Feature properties are specified using tokens like {{field_name}}.</div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>text-font</span>
-    
-    
+
+
   </div>
   <div class='small pad2x'>
     <em class='inline quiet'>
       Optional
       <a href='#string'>string</a>.
     </em>
-    
-    
+
+
   </div>
-  
+
   <div class='small pad2x'>Font stack to use for displaying text.</div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>text-max-size</span>
-    
-    
+
+
   </div>
   <div class='small pad2x'>
     <em class='inline quiet'>
       Optional
       <a href='#number'>number</a>.
     </em>
-    
+
     <span class='space-right quiet'>
       <em>Defaults to </em> <var>16</var>.
     </span>
   </div>
-  
+
   <div class='small pad2x'>The maximum size text will be displayed.</div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>text-max-width</span>
-    
-    
+
+
   </div>
   <div class='small pad2x'>
     <em class='inline quiet'>
       Optional
       <a href='#number'>number</a>.
     </em>
-    
+
     <span class='space-right quiet'>
       <em>Defaults to </em> <var>15</var>.
     </span>
   </div>
-  
+
   <div class='small pad2x'>The maximum line width for text wrapping (em).</div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>text-line-height</span>
-    
-    
+
+
   </div>
   <div class='small pad2x'>
     <em class='inline quiet'>
       Optional
       <a href='#number'>number</a>.
     </em>
-    
+
     <span class='space-right quiet'>
       <em>Defaults to </em> <var>1.2</var>.
     </span>
   </div>
-  
+
   <div class='small pad2x'>Text leading value for multi-line text.</div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>text-letter-spacing</span>
-    
-    
+
+
   </div>
   <div class='small pad2x'>
     <em class='inline quiet'>
       Optional
       <a href='#number'>number</a>.
     </em>
-    
-    
+
+
   </div>
-  
+
   <div class='small pad2x'>Text kerning value (em).</div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>text-justify</span>
-    
-    
+
+
   </div>
   <div class='small pad2x'>
     <em class='inline quiet'>
@@ -1152,17 +1152,17 @@ navigation:
       <em>Defaults to </em> <var>center</var>.
     </span>
   </div>
-  
+
   <div class='small pad2x'>Text justification options.</div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>text-horizontal-align</span>
-    
-    
+
+
   </div>
   <div class='small pad2x'>
     <em class='inline quiet'>
@@ -1176,17 +1176,17 @@ navigation:
       <em>Defaults to </em> <var>center</var>.
     </span>
   </div>
-  
+
   <div class='small pad2x'>Horizontal alignment of the text relative to the anchor.</div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>text-vertical-align</span>
-    
-    
+
+
   </div>
   <div class='small pad2x'>
     <em class='inline quiet'>
@@ -1200,121 +1200,121 @@ navigation:
       <em>Defaults to </em> <var>center</var>.
     </span>
   </div>
-  
+
   <div class='small pad2x'>Vertical alignment of the text relative to the anchor.</div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>text-max-angle</span>
-    
-    
+
+
   </div>
   <div class='small pad2x'>
     <em class='inline quiet'>
       Optional
       <a href='#number'>number</a>.
     </em>
-    
+
     <span class='space-right quiet'>
       <em>Defaults to </em> <var>3.14</var>.
     </span>
   </div>
-  
+
   <div class='small pad2x'>The maximum angle change, in radians, allowed between adjacent characters.</div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>text-rotate</span>
-    
-    
+
+
   </div>
   <div class='small pad2x'>
     <em class='inline quiet'>
       Optional
       <a href='#number'>number</a>.
     </em>
-    
-    
+
+
   </div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>text-slant</span>
-    
-    
+
+
   </div>
   <div class='small pad2x'>
     <em class='inline quiet'>
       Optional
       <a href='#number'>number</a>.
     </em>
-    
-    
+
+
   </div>
-  
+
   <div class='small pad2x'>@TODO</div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>text-padding</span>
-    
-    
+
+
   </div>
   <div class='small pad2x'>
     <em class='inline quiet'>
       Optional
       <a href='#number'>number</a>.
     </em>
-    
+
     <span class='space-right quiet'>
       <em>Defaults to </em> <var>2</var>.
     </span>
   </div>
-  
+
   <div class='small pad2x'>Padding value around text bounding box to avoid label collisions (px).</div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>text-keep-upright</span>
-    
-    
+
+
   </div>
   <div class='small pad2x'>
     <em class='inline quiet'>
       Optional
       <a href='#boolean'>boolean</a>.
     </em>
-    
+
     <span class='space-right quiet'>
       <em>Defaults to </em> <var>true</var>.
     </span>
   </div>
-  
+
   <div class='small pad2x'>If true, the direction of the text may be flipped to prevent it from being rendered upside-down</div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>text-transform</span>
-    
-    
+
+
   </div>
   <div class='small pad2x'>
     <em class='inline quiet'>
@@ -1328,10 +1328,10 @@ navigation:
       <em>Defaults to </em> <var>none</var>.
     </span>
   </div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>text-offset</span>
@@ -1343,20 +1343,20 @@ navigation:
       Optional
       <a href='#array'>array</a>.
     </em>
-    
+
     <span class='space-right quiet'>
       <em>Defaults to </em> <var>0,0</var>.
     </span>
   </div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>text-translate-anchor</span>
-    
-    
+
+
   </div>
   <div class='small pad2x'>
     <em class='inline quiet'>
@@ -1370,72 +1370,72 @@ navigation:
       <em>Defaults to </em> <var>map</var>.
     </span>
   </div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>text-allow-overlap</span>
-    
-    
+
+
   </div>
   <div class='small pad2x'>
     <em class='inline quiet'>
       Optional
       <a href='#boolean'>boolean</a>.
     </em>
-    
-    
+
+
   </div>
-  
+
   <div class='small pad2x'>If true, the text will be visible even if it collides with other icons and labels.</div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>text-ignore-placement</span>
-    
-    
+
+
   </div>
   <div class='small pad2x'>
     <em class='inline quiet'>
       Optional
       <a href='#boolean'>boolean</a>.
     </em>
-    
-    
+
+
   </div>
-  
+
   <div class='small pad2x'>If true, the text won't affect placement of other icons and labels.</div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>text-optional</span>
-    
-    
+
+
   </div>
   <div class='small pad2x'>
     <em class='inline quiet'>
       Optional
       <a href='#boolean'>boolean</a>.
     </em>
-    
-    
+
+
   </div>
-  
+
   <div class='small pad2x'>If true, icons can be shown without their corresponding text.</div>
-  
+
 </div>
 
-        
+
       </div>
-      
+
     </div>
 
     <div id='class' class='pad2'>
@@ -1443,10 +1443,10 @@ navigation:
       <p>Each layer can include one or more <code>style</code> objects defining how to style data for that layer. The style type should be one of <em>fill, line, symbol, background, composite, raster</em>.</p>
     </div>
     <div class='round space-bottom4 fill-white keyline-all'>
-      
+
       <div id='class_fill' class='pad2 keyline-bottom'>
         <h3 class='space-bottom1'><a href='#class_fill' title='link to class: fill'>Class: fill</a></h3>
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>fill-enabled</span>
@@ -1458,37 +1458,37 @@ navigation:
       Optional
       <a href='#boolean'>boolean</a>.
     </em>
-    
+
     <span class='space-right quiet'>
       <em>Defaults to </em> <var>true</var>.
     </span>
   </div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>fill-antialias</span>
     <span class='icon levels inline quiet'></span>
-    
+
   </div>
   <div class='small pad2x'>
     <em class='inline quiet'>
       Optional
       <a href='#boolean'>boolean</a>.
     </em>
-    
+
     <span class='space-right quiet'>
       <em>Defaults to </em> <var>true</var>.
     </span>
   </div>
-  
+
   <div class='small pad2x'>Whether or not the fill should be antialiased.</div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>fill-opacity</span>
@@ -1500,15 +1500,15 @@ navigation:
       Optional
       <a href='#number'>number</a>.
     </em>
-    
+
     <span class='space-right quiet'>
       <em>Defaults to </em> <var>1</var>.
     </span>
   </div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>fill-color</span>
@@ -1520,19 +1520,19 @@ navigation:
       Optional
       <a href='#color'>color</a>.
     </em>
-    
+
     <span class='space-right quiet'>
       <em>Defaults to </em> <var>0,0,0,1</var>.
     </span>
   </div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>fill-outline-color</span>
-    
+
     <span class='icon opacity inline quiet'></span>
   </div>
   <div class='small pad2x'>
@@ -1540,15 +1540,15 @@ navigation:
       Optional
       <a href='#color'>color</a>.
     </em>
-    
-    
+
+
   </div>
-  
+
   <div class='small pad2x'>The outline color of the fill. Matches the value of 'fill-color' if unspecified.</div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>fill-translate</span>
@@ -1560,20 +1560,20 @@ navigation:
       Optional
       <a href='#array'>array</a>.
     </em>
-    
+
     <span class='space-right quiet'>
       <em>Defaults to </em> <var>0,0</var>.
     </span>
   </div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>fill-translate-anchor</span>
-    
-    
+
+
   </div>
   <div class='small pad2x'>
     <em class='inline quiet'>
@@ -1587,33 +1587,33 @@ navigation:
       <em>Defaults to </em> <var>map</var>.
     </span>
   </div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>fill-image</span>
-    
-    
+
+
   </div>
   <div class='small pad2x'>
     <em class='inline quiet'>
       Optional
       <a href='#string'>string</a>.
     </em>
-    
-    
+
+
   </div>
-  
+
 </div>
 
-        
+
       </div>
-      
+
       <div id='class_line' class='pad2 keyline-bottom'>
         <h3 class='space-bottom1'><a href='#class_line' title='link to class: line'>Class: line</a></h3>
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>line-enabled</span>
@@ -1625,15 +1625,15 @@ navigation:
       Optional
       <a href='#boolean'>boolean</a>.
     </em>
-    
+
     <span class='space-right quiet'>
       <em>Defaults to </em> <var>true</var>.
     </span>
   </div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>line-opacity</span>
@@ -1645,19 +1645,19 @@ navigation:
       Optional
       <a href='#number'>number</a>.
     </em>
-    
+
     <span class='space-right quiet'>
       <em>Defaults to </em> <var>1</var>.
     </span>
   </div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>line-color</span>
-    
+
     <span class='icon opacity inline quiet'></span>
   </div>
   <div class='small pad2x'>
@@ -1665,15 +1665,15 @@ navigation:
       Optional
       <a href='#color'>color</a>.
     </em>
-    
+
     <span class='space-right quiet'>
       <em>Defaults to </em> <var>0,0,0,1</var>.
     </span>
   </div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>line-translate</span>
@@ -1685,20 +1685,20 @@ navigation:
       Optional
       <a href='#array'>array</a>.
     </em>
-    
+
     <span class='space-right quiet'>
       <em>Defaults to </em> <var>0,0</var>.
     </span>
   </div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>line-translate-anchor</span>
-    
-    
+
+
   </div>
   <div class='small pad2x'>
     <em class='inline quiet'>
@@ -1712,10 +1712,10 @@ navigation:
       <em>Defaults to </em> <var>map</var>.
     </span>
   </div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>line-width</span>
@@ -1727,15 +1727,15 @@ navigation:
       Optional
       <a href='#number'>number</a>.
     </em>
-    
+
     <span class='space-right quiet'>
       <em>Defaults to </em> <var>1</var>.
     </span>
   </div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>line-offset</span>
@@ -1747,15 +1747,15 @@ navigation:
       Optional
       <a href='#number'>number</a>.
     </em>
-    
-    
+
+
   </div>
-  
+
   <div class='small pad2x'>Offset from the center line.</div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>line-blur</span>
@@ -1767,15 +1767,15 @@ navigation:
       Optional
       <a href='#number'>number</a>.
     </em>
-    
+
     <span class='space-right quiet'>
       <em>Defaults to </em> <var>1</var>.
     </span>
   </div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>line-dasharray</span>
@@ -1787,40 +1787,40 @@ navigation:
       Optional
       <a href='#array'>array</a>.
     </em>
-    
+
     <span class='space-right quiet'>
       <em>Defaults to </em> <var>1,-1</var>.
     </span>
   </div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>line-image</span>
-    
-    
+
+
   </div>
   <div class='small pad2x'>
     <em class='inline quiet'>
       Optional
       <a href='#string'>string</a>.
     </em>
-    
-    
+
+
   </div>
-  
+
   <div class='small pad2x'>Name of image in sprite to use for drawing image lines.</div>
-  
+
 </div>
 
-        
+
       </div>
-      
+
       <div id='class_symbol' class='pad2 keyline-bottom'>
         <h3 class='space-bottom1'><a href='#class_symbol' title='link to class: symbol'>Class: symbol</a></h3>
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>icon-enabled</span>
@@ -1832,15 +1832,15 @@ navigation:
       Optional
       <a href='#boolean'>boolean</a>.
     </em>
-    
+
     <span class='space-right quiet'>
       <em>Defaults to </em> <var>true</var>.
     </span>
   </div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>icon-opacity</span>
@@ -1852,33 +1852,33 @@ navigation:
       Optional
       <a href='#number'>number</a>.
     </em>
-    
+
     <span class='space-right quiet'>
       <em>Defaults to </em> <var>1</var>.
     </span>
   </div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>icon-rotate</span>
     <span class='icon levels inline quiet'></span>
-    
+
   </div>
   <div class='small pad2x'>
     <em class='inline quiet'>
       Optional
       <a href='#number'>number</a>.
     </em>
-    
-    
+
+
   </div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>icon-size</span>
@@ -1890,21 +1890,21 @@ navigation:
       Optional
       <a href='#number'>number</a>.
     </em>
-    
+
     <span class='space-right quiet'>
       <em>Defaults to </em> <var>1</var>.
     </span>
   </div>
-  
+
   <div class='small pad2x'>The amount to scale the icon by. 1 is original size, 3 triples the size.</div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>icon-color</span>
-    
+
     <span class='icon opacity inline quiet'></span>
   </div>
   <div class='small pad2x'>
@@ -1912,21 +1912,21 @@ navigation:
       Optional
       <a href='#color'>color</a>.
     </em>
-    
+
     <span class='space-right quiet'>
       <em>Defaults to </em> <var>0,0,0,1</var>.
     </span>
   </div>
-  
+
   <div class='small pad2x'>The color of the icon. This can only be used with sdf icons.</div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>icon-halo-color</span>
-    
+
     <span class='icon opacity inline quiet'></span>
   </div>
   <div class='small pad2x'>
@@ -1934,15 +1934,15 @@ navigation:
       Optional
       <a href='#color'>color</a>.
     </em>
-    
+
     <span class='space-right quiet'>
       <em>Defaults to </em> <var>0,0,0,0</var>.
     </span>
   </div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>icon-halo-width</span>
@@ -1954,17 +1954,17 @@ navigation:
       Optional
       <a href='#number'>number</a>.
     </em>
-    
+
     <span class='space-right quiet'>
       <em>Defaults to </em> <var>0.25</var>.
     </span>
   </div>
-  
+
   <div class='small pad2x'>How far away the halo is from the icon outline. A value of 0.75 means that it is as wide as the font outline. Lower values make the halo bigger, higher values make it smaller. TODO: Refactor this to be more sane.</div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>icon-halo-blur</span>
@@ -1976,17 +1976,17 @@ navigation:
       Optional
       <a href='#number'>number</a>.
     </em>
-    
+
     <span class='space-right quiet'>
       <em>Defaults to </em> <var>1</var>.
     </span>
   </div>
-  
+
   <div class='small pad2x'>Fade out the halo towards the outside. 1 means no fade out. Higher values mean a higher fade out.</div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>icon-translate</span>
@@ -1998,15 +1998,15 @@ navigation:
       Optional
       <a href='#array'>array</a>.
     </em>
-    
+
     <span class='space-right quiet'>
       <em>Defaults to </em> <var>0,0</var>.
     </span>
   </div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>text-enabled</span>
@@ -2018,15 +2018,15 @@ navigation:
       Optional
       <a href='#boolean'>boolean</a>.
     </em>
-    
+
     <span class='space-right quiet'>
       <em>Defaults to </em> <var>true</var>.
     </span>
   </div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>text-opacity</span>
@@ -2038,15 +2038,15 @@ navigation:
       Optional
       <a href='#number'>number</a>.
     </em>
-    
+
     <span class='space-right quiet'>
       <em>Defaults to </em> <var>1</var>.
     </span>
   </div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>text-size</span>
@@ -2058,21 +2058,21 @@ navigation:
       Optional
       <a href='#number'>number</a>.
     </em>
-    
+
     <span class='space-right quiet'>
       <em>Defaults to </em> <var>16</var>.
     </span>
   </div>
-  
+
   <div class='small pad2x'>Font size in pixels. If unspecified, the text will be as big as allowed by the layer definition.</div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>text-color</span>
-    
+
     <span class='icon opacity inline quiet'></span>
   </div>
   <div class='small pad2x'>
@@ -2080,19 +2080,19 @@ navigation:
       Optional
       <a href='#color'>color</a>.
     </em>
-    
+
     <span class='space-right quiet'>
       <em>Defaults to </em> <var>0,0,0,1</var>.
     </span>
   </div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>text-halo-color</span>
-    
+
     <span class='icon opacity inline quiet'></span>
   </div>
   <div class='small pad2x'>
@@ -2100,15 +2100,15 @@ navigation:
       Optional
       <a href='#color'>color</a>.
     </em>
-    
+
     <span class='space-right quiet'>
       <em>Defaults to </em> <var>0,0,0,0</var>.
     </span>
   </div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>text-halo-width</span>
@@ -2120,17 +2120,17 @@ navigation:
       Optional
       <a href='#number'>number</a>.
     </em>
-    
+
     <span class='space-right quiet'>
       <em>Defaults to </em> <var>0.25</var>.
     </span>
   </div>
-  
+
   <div class='small pad2x'>How far away the halo is from the font outline. A value of 0.75 means that it is as wide as the font outline. Lower values make the halo bigger, higher values make it smaller. TODO: Refactor this to be more sane.</div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>text-halo-blur</span>
@@ -2142,17 +2142,17 @@ navigation:
       Optional
       <a href='#number'>number</a>.
     </em>
-    
+
     <span class='space-right quiet'>
       <em>Defaults to </em> <var>1</var>.
     </span>
   </div>
-  
+
   <div class='small pad2x'>Fade out the halo towards the outside. 1 means no fade out. Higher values mean a higher fade out.</div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>text-translate</span>
@@ -2164,20 +2164,20 @@ navigation:
       Optional
       <a href='#array'>array</a>.
     </em>
-    
+
     <span class='space-right quiet'>
       <em>Defaults to </em> <var>0,0</var>.
     </span>
   </div>
-  
+
 </div>
 
-        
+
       </div>
-      
+
       <div id='class_background' class='pad2 keyline-bottom'>
         <h3 class='space-bottom1'><a href='#class_background' title='link to class: background'>Class: background</a></h3>
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>background-color</span>
@@ -2189,38 +2189,38 @@ navigation:
       Optional
       <a href='#color'>color</a>.
     </em>
-    
+
     <span class='space-right quiet'>
       <em>Defaults to </em> <var>0,0,0,1</var>.
     </span>
   </div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>background-image</span>
-    
-    
+
+
   </div>
   <div class='small pad2x'>
     <em class='inline quiet'>
       Optional
       <a href='#string'>string</a>.
     </em>
-    
-    
+
+
   </div>
-  
+
 </div>
 
-        
+
       </div>
-      
+
       <div id='class_composite' class='pad2 keyline-bottom'>
         <h3 class='space-bottom1'><a href='#class_composite' title='link to class: composite'>Class: composite</a></h3>
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>composite-enabled</span>
@@ -2232,15 +2232,15 @@ navigation:
       Optional
       <a href='#boolean'>boolean</a>.
     </em>
-    
+
     <span class='space-right quiet'>
       <em>Defaults to </em> <var>true</var>.
     </span>
   </div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>composite-opacity</span>
@@ -2252,20 +2252,20 @@ navigation:
       Optional
       <a href='#number'>number</a>.
     </em>
-    
+
     <span class='space-right quiet'>
       <em>Defaults to </em> <var>1</var>.
     </span>
   </div>
-  
+
 </div>
 
-        
+
       </div>
-      
+
       <div id='class_raster' class='pad2 '>
         <h3 class='space-bottom1'><a href='#class_raster' title='link to class: raster'>Class: raster</a></h3>
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>raster-enabled</span>
@@ -2277,19 +2277,19 @@ navigation:
       Optional
       <a href='#boolean'>boolean</a>.
     </em>
-    
+
     <span class='space-right quiet'>
       <em>Defaults to </em> <var>true</var>.
     </span>
   </div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>raster-opacity</span>
-    
+
     <span class='icon opacity inline quiet'></span>
   </div>
   <div class='small pad2x'>
@@ -2297,15 +2297,15 @@ navigation:
       Optional
       <a href='#number'>number</a>.
     </em>
-    
+
     <span class='space-right quiet'>
       <em>Defaults to </em> <var>1</var>.
     </span>
   </div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>raster-spin</span>
@@ -2317,13 +2317,13 @@ navigation:
       Optional
       <a href='#number'>number</a>.
     </em>
-    
-    
+
+
   </div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>raster-brightness</span>
@@ -2335,15 +2335,15 @@ navigation:
       Optional
       <a href='#array'>array</a>.
     </em>
-    
+
     <span class='space-right quiet'>
       <em>Defaults to </em> <var>0,1</var>.
     </span>
   </div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>raster-saturation</span>
@@ -2355,13 +2355,13 @@ navigation:
       Optional
       <a href='#number'>number</a>.
     </em>
-    
-    
+
+
   </div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>raster-contrast</span>
@@ -2373,13 +2373,13 @@ navigation:
       Optional
       <a href='#number'>number</a>.
     </em>
-    
-    
+
+
   </div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>raster-fade</span>
@@ -2391,97 +2391,97 @@ navigation:
       Optional
       <a href='#number'>number</a>.
     </em>
-    
-    
+
+
   </div>
-  
+
 </div>
 
-        
+
       </div>
-      
+
     </div>
 
     <div id='rasterize' class='round keyline-all fill-white pad2 space-bottom4'>
       <h2><a href='#rasterize' title='link to rasterize'>rasterize</a></h2>
       <div class='space-bottom1'>
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>enabled</span>
     <span class='icon levels inline quiet'></span>
-    
+
   </div>
   <div class='small pad2x'>
     <em class='inline quiet'>
       Optional
       <a href='#boolean'>boolean</a>.
     </em>
-    
-    
+
+
   </div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>buffer</span>
     <span class='icon levels inline quiet'></span>
-    
+
   </div>
   <div class='small pad2x'>
     <em class='inline quiet'>
       Optional
       <a href='#number'>number</a>.
     </em>
-    
+
     <span class='space-right quiet'>
       <em>Defaults to </em> <var>0.03125</var>.
     </span>
   </div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>size</span>
     <span class='icon levels inline quiet'></span>
-    
+
   </div>
   <div class='small pad2x'>
     <em class='inline quiet'>
       Optional
       <a href='#number'>number</a>.
     </em>
-    
+
     <span class='space-right quiet'>
       <em>Defaults to </em> <var>256</var>.
     </span>
   </div>
-  
+
 </div>
 
-        
+
         <div class='col12 clearfix pad0y'>
   <div>
     <span class='code space-right'>blur</span>
     <span class='icon levels inline quiet'></span>
-    
+
   </div>
   <div class='small pad2x'>
     <em class='inline quiet'>
       Optional
       <a href='#number'>number</a>.
     </em>
-    
-    
+
+
   </div>
-  
+
 </div>
 
-        
+
       </div>
     </div>
 
@@ -2520,7 +2520,7 @@ navigation:
         <p class='small'>A string is basically just text. In the case of Mapbox GL, you're going to put it in quotes. Strings can be anything, though pay attention to the case of <code>text-name</code> - it actually will refer to features, which you refer to by putting them in curly braces, as seen in the example below.</p>
 {% highlight json %}
 {
-  "text-name": "{{MY_FIELD}}"
+  "text-name": "{MY_FIELD}"
 }
 {% endhighlight %}
       </div>


### PR DESCRIPTION
Looks like my editor has space problems. Really just for [this](https://github.com/mapbox/mapbox-gl-style-spec/blob/ec729dd28480013339e213958ce4b5845054d8db/docs/_generate/index.html#L269)

```
-  "text-name": "{{MY_FIELD}}"
 +  "text-name": "{MY_FIELD}"
```

related to [js pull #533](https://github.com/mapbox/mapbox-gl-js/pull/533)
