### PR TITLE
change text-max-angle default and doc to degrees

### DIFF
--- a/reference/v4.json
+++ b/reference/v4.json
@@ -375,7 +375,7 @@
     },
     "text-max-angle": {
       "type": "number",
-      "default": 50,
+      "default": 45,
       "doc": "The maximum angle change, in degrees, allowed between adjacent characters."
     },
     "text-rotate": {


### PR DESCRIPTION
per #92 and related to https://github.com/mapbox/mapbox-gl-js/pull/547
I changed the default to 50 degrees as a less crazy default than 180, but @nickidlugash it would be great if you had any input on what a sensible default might be? /cc @yhahn @ansis 
