### PR TITLE
make rasterize part of the raster render type

### DIFF
--- a/reference/v4.json
+++ b/reference/v4.json
@@ -139,10 +139,6 @@
       "value": "layer",
       "doc": "If 'type' is 'composite', the child layers are composited together onto the previous level layer level."
     },
-    "rasterize": {
-      "type": "rasterize",
-      "doc": "Options for rasterizing and applying raster affects to a layer prior to display."
-    },
     "style": {
       "type": "class",
       "doc": "Default style properties for this layer."
@@ -150,31 +146,6 @@
     "style.*": {
       "type": "class",
       "doc": "Override style properties for this layer. The class name is the part after the first dot."
-    }
-  },
-  "rasterize": {
-    "enabled": {
-      "type": "boolean",
-      "function": true,
-      "default": false,
-      "doc": "Display a layer as a prerendered texture rather than directly."
-    },
-    "buffer": {
-      "type": "number",
-      "function": true,
-      "default": 0.03125
-    },
-    "size": {
-      "type": "number",
-      "function": true,
-      "default": 256,
-      "doc": "The texture image size (in pixels). Will automatically by scaled to match the visual tile size."
-    },
-    "blur": {
-      "type": "number",
-      "function": true,
-      "default": 0,
-      "doc": "Blur radius to apply to the raster texture before display."
     }
   },
   "render": [
@@ -440,6 +411,23 @@
   "render_composite": {
   },
   "render_raster": {
+    "raster-size": {
+      "type": "number",
+      "function": true,
+      "default": 256,
+      "doc": "The texture image size (in pixels) vector layers will be rasterized at. Will automatically by scaled to match the visual tile size."
+    },
+    "raster-blur": {
+      "type": "number",
+      "function": true,
+      "default": 0,
+      "doc": "Blur radius to apply to the raster texture before display."
+    },
+    "raster-buffer": {
+        "type": "number",
+        "function": true,
+        "default": 0.03125
+    }
   },
   "filter": [
     {


### PR DESCRIPTION
From voice with @kkaefer yesterday we should make rasterizing and blurring vector layers part of the raster render type. This will let us rasterize multiple layers together (performance) and treat rasterized layers just like any raster tiles (cross-fading, opacity).

In this example it would draw the full_shadow and medium_shadow into raster tiles together, and then draw them to the screen at 0.5 opacity.

``` js
{
    "id": "hillshades",
    "type": "raster",
    "render": {
        "raster-size": 512,
        "raster-blur": 2,
    },                                          
    "style": {  
        "raster-opacity": 0.5
    },                              
    "layers": [     
        { "id": "full_shadow", "type": "fill", "render": {}, ... },
        { "id": "medium_shadow", "type": "fill", "render": {}, ... },
        ...                         
    ]   
}
```

No migration is needed because none of the styles being migrated have this.

@kkaefer @lbud @mourner 
