### PR TITLE
remove fill-winding

### DIFF
--- a/reference/v4.json
+++ b/reference/v4.json
@@ -164,14 +164,6 @@
   "render_background": {
   },
   "render_fill": {
-    "fill-winding": {
-      "type": "enum",
-      "values": [
-        "non-zero",
-        "even-odd"
-      ],
-      "default": "non-zero"
-    }
   },
   "render_line": {
     "line-cap": {


### PR DESCRIPTION
Should we remove `fill-winding`? When would this be used?

@kkaefer @mourner @nickidlugash 

Fill winding currently determines how overlapping polygon areas get treated. In the current spec, the even-odd option would mean that areas covered by an even number of polygons would get counted as not being within the polygon.

![](http://upload.wikimedia.org/wikipedia/commons/thumb/f/f8/Even-odd_and_non-zero_winding_fill_rules.png/1258px-Even-odd_and_non-zero_winding_fill_rules.png)
