### PR TITLE
icon-halo-width unit update

### DIFF
--- a/reference/v4.json
+++ b/reference/v4.json
@@ -708,17 +708,17 @@
     },
     "icon-halo-width": {
       "type": "number",
-      "default": 0.25,
+      "default": 0,
       "function": true,
       "transition": true,
-      "doc": "How far away the halo is from the icon outline. A value of 0.75 means that it is as wide as the font outline. Lower values make the halo bigger, higher values make it smaller. TODO: Refactor this to be more sane."
+      "doc": "How far away the halo is from the icon outline, in pixels."
     },
     "icon-halo-blur": {
       "type": "number",
-      "default": 1,
+      "default": 0,
       "function": true,
       "transition": true,
-      "doc": "Fade out the halo towards the outside. 1 means no fade out. Higher values mean a higher fade out."
+      "doc": "Fade out the halo towards the outside, in pixels."
     },
     "icon-translate": {
       "type": "array",


### PR DESCRIPTION
@ansis just want to clarify on this -- I know text-halos max out at 1/4 of the text size. Do icons behave the same? I'm asking because I'm just not sure how [this](https://github.com/mapbox/mapbox-gl-js/blob/dev-pages/js/render/drawsymbol.js#L110) should affect them...
