### PR TITLE
add `symbol-avoid-edges`

### DIFF
--- a/reference/v4.json
+++ b/reference/v4.json
@@ -212,6 +212,11 @@
       "default": 250,
       "doc": "Minimum distance between two symbol anchors (px)"
     },
+    "symbol-avoid-edges": {
+        "type": "boolean",
+        "default": false,
+        "doc": "If true, the symbols will not cross tile edges. Symbols that cross tile edges may cause collisions in some cases. This property should be set to true if the layer does not have enough padding in the vector tile to prevent collisions, or if it is a point symbol layer placed after a line symbol layer."
+    },
     "icon-allow-overlap": {
         "type": "boolean",
         "default": false,


### PR DESCRIPTION
Cross tile labels will work the same way they do in mapnik maps. The vectortiles are padded with extra data that gets used to prevent most collisions. `symbol-avoid-edges` can be used to disable cross-tile labels in the cases this approach does not work well enough.

The default value is false for point symbols. It is always true for line symbols because the line interpolation can't be predicted across tiles, making it pretty much impossible to prevent collisions.

`"symbol-avoid-edges": true` should be used:
- if a layer does not have enough padding in the vector tiles to safely place the label
- if a point layer is placed after a line layer
