### PR TITLE
[not ready] add tiles option for remote sources

### DIFF
--- a/reference/v4.json
+++ b/reference/v4.json
@@ -65,10 +65,13 @@
       "doc": "The data type of the source."
     },
     "url": {
-      "required": true,
       "type": "string",
-      "doc": "A URL, or URL template to retrive the source data."
+      "doc": "A URL, or URL template to retrive the source data. If not a `mapbox://` source, this should point to a tileJSON endpoint. One of either `url` or `tiles` is required."
     },
+    "tiles": {
+      "type": "string",
+      "doc": "An array of one or more tile source URLs, as in the tileJSON spec. One of either `url` or `tiles` is required."
+    }
     "tileSize": {
       "type": "number",
       "default": 512,


### PR DESCRIPTION
See https://github.com/mapbox/mapbox-gl-js/pull/697
Questions:
- Should we rename `minZoom` and `maxZoom` everywhere to `minzoom` and `maxzoom` to match tileJSON?
- Should we add more specific options rather than just wildcarding it for tileJSON things like `attribution`, `center`, `bounds`? (We probably should if we modify GL to do something with those...)
