### PR TITLE
increase line-round-limit to create less vertices

### DIFF
--- a/reference/v8.json
+++ b/reference/v8.json
@@ -361,7 +361,7 @@
     },
     "line-round-limit": {
       "type": "number",
-      "default": 1,
+      "default": 1.05,
       "function": "interpolated",
       "scale": true,
       "doc": "Used to automatically convert round joins to miter joins for shallow angles.",


### PR DESCRIPTION
With `"line-join": "round"` and `"line-round-limit": 1` a semi-circle was added at every join. By increasing the default value to `1.05`, miters joins are used for corners that aren't sharp enough for the round join to be noticeable. This decreases the number of vertices for these lines by more than half in most cases.