### PR TITLE
Fix misleading source example

### DIFF
--- a/docs/_generate/index.html
+++ b/docs/_generate/index.html
@@ -207,8 +207,8 @@ navigation:
 "mapbox-streets": {
   "type": "vector",
   "tiles": [
-    "http://a.example.com/tiles/{z}/{x}/{y}.png",
-    "http://b.example.com/tiles/{z}/{x}/{y}.png"
+    "http://a.example.com/tiles/{z}/{x}/{y}.pbf",
+    "http://b.example.com/tiles/{z}/{x}/{y}.pbf"
   ],
   "maxzoom": 14
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -529,8 +529,8 @@ navigation:
 "mapbox-streets": {
   "type": "vector",
   "tiles": [
-    "http://a.example.com/tiles/{z}/{x}/{y}.png",
-    "http://b.example.com/tiles/{z}/{x}/{y}.png"
+    "http://a.example.com/tiles/{z}/{x}/{y}.pbf",
+    "http://b.example.com/tiles/{z}/{x}/{y}.pbf"
   ],
   "maxzoom": 14
 }


### PR DESCRIPTION
Although an HTTP request ending with `.png` could return anything, this particular source is referring to vector tiles, so an example with an URL ending in `.pbf` is more appropriated.