### PR TITLE
Make it clear that text-rotate is not an interpolated property

### DIFF
--- a/reference/v7.json
+++ b/reference/v7.json
@@ -542,7 +542,7 @@
       "default": 0,
       "period": 360,
       "units": "degrees",
-      "function": "interpolated",
+      "function": "piecewise-constant",
       "doc": "Rotates the text clockwise.",
       "requires": [
         "text-field"


### PR DESCRIPTION
Fixes https://github.com/mapbox/mapbox-gl-style-spec/issues/306