### PR TITLE
Add 'pitch' as a $root property

### DIFF
--- a/reference/v8.json
+++ b/reference/v8.json
@@ -33,6 +33,12 @@
       "units": "degrees",
       "doc": "Default bearing, in degrees."
     },
+    "pitch": {
+      "type": "number",
+      "default": 0,
+      "units": "degrees",
+      "doc": "Default pitch, in degrees. Zero is perpendicular to the surface"
+    },
     "sources": {
       "required": true,
       "type": "sources",

--- a/test/fixture/pitch.input.json
+++ b/test/fixture/pitch.input.json
@@ -1,0 +1,6 @@
+{
+  "version": 8,
+  "pitch": "45",
+  "sources": {},
+  "layers": []
+}

--- a/test/fixture/pitch.output.json
+++ b/test/fixture/pitch.output.json
@@ -1,0 +1,6 @@
+[
+  {
+    "message": "pitch: number expected, string found",
+    "line": 3
+  }
+]


### PR DESCRIPTION
'pitch' follows 'center', 'zoom' and 'bearing' to define the default
camera position. 0 degrees is perpendicular to the surface.

Issue: #341