### PR TITLE
Future proof url.parse() for font stack v8 migrations

### DIFF
--- a/migrations/v8.js
+++ b/migrations/v8.js
@@ -179,13 +179,13 @@ module.exports = function(style) {
             return input;
 
         } else if (inputParsed.hostname === 'fontstack') {
-            assert(inputParsed.pathname === '/{fontstack}/{range}.pbf');
+            assert(decodeURI(inputParsed.pathname) === '/{fontstack}/{range}.pbf');
             return 'mapbox://fonts/mapbox/{fontstack}/{range}.pbf';
 
         } else if (inputParsed.hostname === 'fonts') {
             assert(inputPathnameParts[1] === 'v1');
-            assert(inputPathnameParts[3] === '{fontstack}');
-            assert(inputPathnameParts[4] === '{range}.pbf');
+            assert(decodeURI(inputPathnameParts[3]) === '{fontstack}');
+            assert(decodeURI(inputPathnameParts[4]) === '{range}.pbf');
             return 'mapbox://fonts/' + inputPathnameParts[2] + '/{fontstack}/{range}.pbf';
 
         } else {


### PR DESCRIPTION
In new versions of Node and browserify `URL.parse()` URL encodes
properties on the resulting object. This has the effect of breaking the
migration script.

We can decodeURI the path segments we need to compare in a manner that is
backwards and future compatible.

Tested with:
- browserify
- Node 0.10
- IO 3.0