### PR TITLE
add explanation of tile size to pattern docs

### DIFF
--- a/reference/v8.json
+++ b/reference/v8.json
@@ -877,7 +877,7 @@
       "type": "string",
       "function": "piecewise-constant",
       "transition": true,
-      "doc": "Name of image in sprite to use for drawing image fills. For seamless patterns, image width and height must be a factor of two (2, 4, 8, 16, 32, and so on)."
+      "doc": "Name of image in sprite to use for drawing image fills. For seamless patterns, image width and height must be a factor of two (2, 4, 8, ..., 512)."
     }
   },
   "paint_line": {
@@ -973,7 +973,7 @@
       "type": "string",
       "function": "piecewise-constant",
       "transition": true,
-      "doc": "Name of image in sprite to use for drawing image lines."
+      "doc": "Name of image in sprite to use for drawing image lines. For seamless patterns, image width must be a factor of two (2, 4, 8, ..., 512)."
     }
   },
   "paint_circle": {
@@ -1289,7 +1289,7 @@
       "type": "string",
       "function": "piecewise-constant",
       "transition": true,
-      "doc": "Optionally an image which is drawn as the background. For seamless patterns, image width and height must be a factor of two (2, 4, 8, 16, 32, and so on)."
+      "doc": "Name of image in sprite to use for drawing an image background. For seamless patterns, image width and height must be a factor of two (2, 4, 8, ..., 512)."
     },
     "background-opacity": {
       "type": "number",

--- a/reference/v8.json
+++ b/reference/v8.json
@@ -877,7 +877,7 @@
       "type": "string",
       "function": "piecewise-constant",
       "transition": true,
-      "doc": "Name of image in sprite to use for drawing image fills."
+      "doc": "Name of image in sprite to use for drawing image fills. For seamless patterns, image dimensions must be a factor of tile dimensions. Typically, tiles are 512px x 512px so image length and height should equal to 1, 2, 4, 8, 16, 32, 64, 128, 256, or 512."
     }
   },
   "paint_line": {
@@ -1289,7 +1289,7 @@
       "type": "string",
       "function": "piecewise-constant",
       "transition": true,
-      "doc": "Optionally an image which is drawn as the background."
+      "doc": "Optionally an image which is drawn as the background. For seamless patterns, image dimensions must be a factor of tile dimensions. Typically, tiles are 512px x 512px so image length and height should equal to 1, 2, 4, 8, 16, 32, 64, 128, 256, or 512."
     },
     "background-opacity": {
       "type": "number",

--- a/reference/v8.json
+++ b/reference/v8.json
@@ -877,7 +877,7 @@
       "type": "string",
       "function": "piecewise-constant",
       "transition": true,
-      "doc": "Name of image in sprite to use for drawing image fills. For seamless patterns, image dimensions must be a factor of tile dimensions. Typically, tiles are 512px x 512px so image length and height should equal to 1, 2, 4, 8, 16, 32, 64, 128, 256, or 512."
+      "doc": "Name of image in sprite to use for drawing image fills. For seamless patterns, image width and height must be a factor of two (2, 4, 8, 16, 32, and so on)."
     }
   },
   "paint_line": {
@@ -1289,7 +1289,7 @@
       "type": "string",
       "function": "piecewise-constant",
       "transition": true,
-      "doc": "Optionally an image which is drawn as the background. For seamless patterns, image dimensions must be a factor of tile dimensions. Typically, tiles are 512px x 512px so image length and height should equal to 1, 2, 4, 8, 16, 32, 64, 128, 256, or 512."
+      "doc": "Optionally an image which is drawn as the background. For seamless patterns, image width and height must be a factor of two (2, 4, 8, 16, 32, and so on)."
     },
     "background-opacity": {
       "type": "number",


### PR DESCRIPTION
Would be nice if docs explained to users the relationship between tiles and image dimensions. 

@nickidlugash @jfirebaugh let me know what you guys think of this language. I wasn't really sure how to talk about tile size. Can we say with more certainty that tile sizes are 512 rather than saying , "typically...".