### PR TITLE
Line-offset behavior is opposite other offsets

### DIFF
--- a/reference/v8.json
+++ b/reference/v8.json
@@ -986,7 +986,7 @@
     "line-offset": {
       "type": "number",
       "default": 0,
-      "doc": "The line's offset perpendicular to its direction. Values may be positive or negative, where positive indicates \"leftwards\" (if you were moving in the direction of the line) and negative indicates \"rightwards.\"",
+      "doc": "The line's offset perpendicular to its direction. Values may be positive or negative, where positive indicates \"rightwards\" (if you were moving in the direction of the line) and negative indicates \"leftwards.\"",
       "function": "interpolated",
       "transition": true,
       "units": "pixels"


### PR DESCRIPTION
Line offset:

> positive indicates “leftwards” [...] and negative indicates “rightwards.”

Text and icon offset:

> Positive values indicate right and down, while negative values indicate left and up.

When using line-offset and adding icons to the line for labeling the direction of travel the icon-offset must be the inverse of the line-offset.

Shouldn't they be consistent?

cc @kkaefer @lucaswoj
