### PR TITLE
Migrate ramps to ensure validity

### DIFF
--- a/test/migrations/v8.js
+++ b/test/migrations/v8.js
@@ -518,3 +518,168 @@ t('migrate versioned fontstack urls', function (t) {
     t.deepEqual(migrate(input), output);
     t.end();
 });
+
+t('migrate ramp zoom order', function (t) {
+    var input = {
+        "version": 8,
+        "layers": [
+            {
+                "type": "background",
+                "paint": {
+                    "background-color": {
+                        "base": 1,
+                        "stops": [
+                            [9, "#000000"],
+                            [6, "#FFFFFF"]
+                        ]
+                    }
+                }
+            }
+        ]
+    };
+
+    var output = {
+        "version": 8,
+        "layers": [
+            {
+                "type": "background",
+                "paint": {
+                    "background-color": {
+                        "base": 1,
+                        "stops": [
+                            [6, "#FFFFFF"],
+                            [9, "#000000"]
+                        ]
+                    }
+                }
+            }
+        ]
+    };
+
+    t.deepEqual(migrate(input), output);
+    t.end();
+});
+
+t('migrate ramp, zoom collision same value', function (t) {
+    var input = {
+        "version": 8,
+        "layers": [
+            {
+                "type": "background",
+                "paint": {
+                    "background-color": {
+                        "base": 1,
+                        "stops": [
+                            [9, "#000000"],
+                            [9, "#000000"]
+                        ]
+                    }
+                }
+            }
+        ]
+    };
+
+    var output = {
+        "version": 8,
+        "layers": [
+            {
+                "type": "background",
+                "paint": {
+                    "background-color": {
+                        "base": 1,
+                        "stops": [
+                            [9, "#000000"]
+                        ]
+                    }
+                }
+            }
+        ]
+    };
+
+    t.deepEqual(migrate(input), output);
+    t.end();
+});
+
+t('migrate ramp, zoom collisions different value', function (t) {
+    var input = {
+        "version": 8,
+        "layers": [
+            {
+                "type": "background",
+                "paint": {
+                    "background-color": {
+                        "base": 1,
+                        "stops": [
+                            [9, "#000000"],
+                            [9, "#FFFFFF"]
+                        ]
+                    }
+                }
+            }
+        ]
+    };
+
+    var output = {
+        "version": 8,
+        "layers": [
+            {
+                "type": "background",
+                "paint": {
+                    "background-color": {
+                        "base": 1,
+                        "stops": [
+                            [9, "#000000"],
+                            [9.001, "#FFFFFF"]
+                        ]
+                    }
+                }
+            }
+        ]
+    };
+
+    t.deepEqual(migrate(input), output);
+    t.end();
+});
+
+t('migrate ramp zoom collisions recurive', function (t) {
+    var input = {
+        "version": 8,
+        "layers": [
+            {
+                "type": "background",
+                "paint": {
+                    "background-color": {
+                        "base": 1,
+                        "stops": [
+                            [9, "#000000"],
+                            [9.000001, "#999999"],
+                            [9, "#FFFFFF"]
+                        ]
+                    }
+                }
+            }
+        ]
+    };
+
+    var output = {
+        "version": 8,
+        "layers": [
+            {
+                "type": "background",
+                "paint": {
+                    "background-color": {
+                        "base": 1,
+                        "stops": [
+                            [9, "#000000"],
+                            [9.000001, "#999999"],
+                            [9.001, "#FFFFFF"]
+                        ]
+                    }
+                }
+            }
+        ]
+    };
+
+    t.deepEqual(migrate(input), output);
+    t.end();
+});


### PR DESCRIPTION
We added validation checks to make sure that ramp stops are sorted by
zoom level and do not have duplicate stops by zoom. This broke some
styles that have ramps with out of order and/or duplicate stops.

We should migrate these styles ramp to ensure compliance with the new
validations. The migration does the following:
- sorts ramp stops by zoom
- removes duplicate stops
- marginally increments the zoom of a colliding stop with a unique value
  - rerun the migration in case changing the zoom causes a new
    collision/ordering issue
