### PR TITLE
Revert "prevent ramp from having duplicate stops"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## master
 
+* Revert ramp validation checks that broke some styles.
+
 ## 8.4.0
 
 v8.0.0 styles are fully compatible with v8.4.0.

--- a/lib/validate/parsed.js
+++ b/lib/validate/parsed.js
@@ -328,8 +328,8 @@ module.exports = function(style, reference) {
                             error(key + '[0]', val[0], 'zoom level for piecewise-constant functions must be an integer');
                         }
 
-                        if (val[0] <= lastStop) {
-                            error(key + '[0]', val[0], 'array stops must appear in ascending order and have no duplicates');
+                        if (val[0] < lastStop) {
+                            error(key + '[0]', val[0], 'array stops must appear in ascending order');
                         }
 
                         lastStop = val[0];

--- a/test/fixture/functions.input.json
+++ b/test/fixture/functions.input.json
@@ -126,26 +126,6 @@
       }
     },
     {
-      "id": "duplicate-stop",
-      "type": "line",
-      "source": "source",
-      "source-layer": "layer",
-      "paint": {
-        "line-width": {
-          "stops": [
-            [
-              1,
-              0
-            ],
-            [
-              1,
-              0
-            ]
-          ]
-        }
-      }
-    },
-    {
       "id": "v6-array-function",
       "type": "fill",
       "source": "source",

--- a/test/fixture/functions.output.json
+++ b/test/fixture/functions.output.json
@@ -36,23 +36,19 @@
     "line": 102
   },
   {
-    "message": "layers[8].paint.line-width.stops[1][0]: array stops must appear in ascending order and have no duplicates",
+    "message": "layers[8].paint.line-width.stops[1][0]: array stops must appear in ascending order",
     "line": 121
   },
   {
-    "message": "layers[9].paint.line-width.stops[1][0]: array stops must appear in ascending order and have no duplicates",
-    "line": 141
+    "message": "layers[9].paint.fill-translate[0]: number expected, object found",
+    "line": 135
   },
   {
-    "message": "layers[10].paint.fill-translate[0]: number expected, object found",
-    "line": 155
+    "message": "layers[9].paint.fill-translate[1]: number expected, object found",
+    "line": 139
   },
   {
-    "message": "layers[10].paint.fill-translate[1]: number expected, object found",
-    "line": 159
-  },
-  {
-    "message": "layers[12].paint.fill-antialias.stops[0][0]: zoom level for piecewise-constant functions must be an integer",
-    "line": 185
+    "message": "layers[11].paint.fill-antialias.stops[0][0]: zoom level for piecewise-constant functions must be an integer",
+    "line": 165
   }
 ]


### PR DESCRIPTION
This reverts commit e37aa5f678eb472c47bc2388bcc8ec71330e1c3e.

Adding validation of ramp stops was good in spirit, but it breaks some v8
styles. Reverting until v9 where we can make backwards incompatible
changes.
