### PR TITLE
Allow string-keyed object stops for property functions

### DIFF
--- a/lib/validate/validate_function.js
+++ b/lib/validate/validate_function.js
@@ -9,6 +9,7 @@ var validateNumber = require('./validate_number');
 
 module.exports = function validateFunction(options) {
     var originalValueSpec = options.valueSpec;
+    var originalValue = options.value;
 
     var stopKeyType;
 
@@ -76,10 +77,11 @@ module.exports = function validateFunction(options) {
                 objectElementValidators: { zoom: validateNumber, value: validateValue }
             }));
         } else {
-            errors = errors.concat(validate({
+            var isZoomFunction = !originalValue.property;
+            errors = errors.concat((isZoomFunction ? validateNumber : validateValue)({
                 key: key + '[0]',
                 value: value[0],
-                valueSpec: {type: 'number'},
+                valueSpec: {},
                 style: options.style,
                 styleSpec: options.styleSpec
             }));

--- a/test/fixture/functions.input.json
+++ b/test/fixture/functions.input.json
@@ -227,6 +227,29 @@
           "stops": [[{"zoom": 1, "value": { "asdf": true }}, true]]
         }
       }
+  },
+  {
+    "id": "invalid object-keyed string stop for zoom function",
+    "type": "fill",
+    "source": "source",
+    "source-layer": "layer",
+    "paint": {
+      "fill-antialias": {
+        "stops": [["bad", true]]
+      }
     }
+  },
+  {
+    "id": "valid object-keyed string stop for property function",
+    "type": "fill",
+    "source": "source",
+    "source-layer": "layer",
+    "paint": {
+      "fill-antialias": {
+        "property": "mapbox",
+        "stops": [["good", true]]
+      }
+    }
+  }
   ]
 }

--- a/test/fixture/functions.output.json
+++ b/test/fixture/functions.output.json
@@ -52,23 +52,27 @@
     "line": 165
   },
   {
-    "line": 179,
-    "message": "layers[12].paint.fill-antialias.stops[1]: number stop key type must match previous stop key type object"
+    "message": "layers[12].paint.fill-antialias.stops[1]: number stop key type must match previous stop key type object",
+    "line": 179
   },
   {
-    "line": 191,
-    "message": "layers[13].paint.fill-antialias.stops[0]: object stop key must have zoom"
+    "message": "layers[13].paint.fill-antialias.stops[0]: object stop key must have zoom",
+    "line": 191
   },
   {
-    "line": 203,
-    "message": "layers[14].paint.fill-antialias.stops[0]: object stop key must have value"
+    "message": "layers[14].paint.fill-antialias.stops[0]: object stop key must have value",
+    "line": 203
   },
   {
-    "line": 215,
-    "message": "layers[15].paint.fill-antialias.stops[0][0].zoom: number expected, string found"
+    "message": "layers[15].paint.fill-antialias.stops[0][0].zoom: number expected, string found",
+    "line": 215
   },
   {
-    "line": 227,
-    "message": "layers[16].paint.fill-antialias.stops[0][0].value: property value must be a number, string or array"
+    "message": "layers[16].paint.fill-antialias.stops[0][0].value: property value must be a number, string or array",
+    "line": 227
+  },
+  {
+    "message": "layers[17].paint.fill-antialias.stops[0][0]: number expected, string found",
+    "line": 238
   }
 ]


### PR DESCRIPTION
This function should not cause a validation error

``` js
{
  property: 'mapbox',
  stops: [['great', 1], ['swell', 2]]
}
```

Just as this function does not

``` js
{
  property: 'mapbox',
  stops: [[{value: 'great', zoom: 0}, 1], [{value: 'swell', zoom: 0}, 2]]
}
```

cc @ansis 
