### PR TITLE
Docs for EPSG:3857 WMS support in Mapbox GL JS

### DIFF
--- a/docs/_generate/index.html
+++ b/docs/_generate/index.html
@@ -149,7 +149,7 @@ navigation:
       <p>
         Tiled sources (vector and raster) must specify
         their details in terms of the <a href="https://github.com/mapbox/tilejson-spec">TileJSON specification</a>.
-        This can be done in two ways:
+        This can be done in several ways:
       </p>
       <ul>
         <li>
@@ -179,6 +179,23 @@ navigation:
 {% endhighlight %}
           </div>
         </li>
+        <li>
+          By providing a url to a WMS server that supports
+          EPSG:3857 (or EPSG:900913) as a source of tiled data.
+          The server url should contain a <code>"{bbox-epsg-3857}"</code>
+          replacement token to supply the <code>bbox</code> parameter.
+          <em>(This feature is currently supported only in Mapbox GL JS.)</em>
+{% highlight json%}
+"wms-imagery": {
+  "type": "raster",
+  "tiles": [
+  'http://a.example.com/wms?bbox={bbox-epsg-3857}&format=image/png&service=WMS&version=1.1.1&request=GetMap&srs=EPSG:3857&width=256&height=256&layers=example'
+  ],
+  "tileSize": 256
+}
+{% endhighlight %}
+        </li>
+
       </ul>
 
       <div class='space-bottom4 fill-white keyline-all'>
@@ -241,7 +258,7 @@ navigation:
           </div>
         <p>
           This example of a GeoJSON source refers to an external GeoJSON document via its URL. The
-          GeoJSON document must be on the same domain or accessible using 
+          GeoJSON document must be on the same domain or accessible using
           <a href='http://enable-cors.org/'>CORS</a>.
         </p>
   <div class='space-bottom1 clearfix'>


### PR DESCRIPTION
Added a third bullet point about tiled WMS sources..

<img width="802" alt="screenshot 2016-06-21 13 19 25" src="https://cloud.githubusercontent.com/assets/38784/16239523/2e904f4c-37b3-11e6-9495-0b59b66a9ac9.png">
