### PR TITLE
fix type links in docs

### DIFF
--- a/docs/_generate/item.html
+++ b/docs/_generate/item.html
@@ -8,7 +8,7 @@
   <div>
     <em class='inline quiet'>
       <%= prop.required ? 'Required' : 'Optional' %>
-      <% if (prop.type && prop.type !== '*') { %><a href='#<%= prop.type %>'><%= prop.type %></a>.<% } %>
+      <% if (prop.type && prop.type !== '*') { %><a href='#types-<%= prop.type %>'><%= prop.type %></a>.<% } %>
     </em>
     <% if (prop.values) { %><span class='space-right quiet'>
       <em>One of</em> <%= _(prop.values).map(function(opt) { return '<var>' + opt + '</var>' }).join(', ') %>.


### PR DESCRIPTION
The type links in the docs eg. the link at https://www.mapbox.com/mapbox-gl-style-spec/#layer-filter is currently pointing to #filter but the anchor is actually #types-filter. This fixes this.
