### PR TITLE
Add "micro" class to all tables

### DIFF
--- a/docs/_generate/index.html
+++ b/docs/_generate/index.html
@@ -210,7 +210,7 @@ navigation:
 }
 {% endhighlight %}
           </div>
-          <table>
+          <table class="micro">
             <thead>
             <tr class='fill-light'>
               <th>SDK Support</th>
@@ -244,7 +244,7 @@ navigation:
 }
 {% endhighlight %}
           </div>
-          <table>
+          <table class="micro">
             <thead>
             <tr class='fill-light'>
               <th>SDK Support</th>
@@ -300,7 +300,7 @@ navigation:
 }
 {% endhighlight %}
           </div>
-          <table>
+          <table class="micro">
             <thead>
             <tr class='fill-light'>
               <th>SDK Requirements</th>
@@ -347,7 +347,7 @@ navigation:
 }
 {% endhighlight %}
           </div>
-          <table>
+          <table class="micro">
             <thead>
             <tr class='fill-light'>
               <th>SDK Support</th>
@@ -394,7 +394,7 @@ navigation:
 }
 {% endhighlight %}
           </div>
-          <table>
+          <table class="micro">
             <thead>
             <tr class='fill-light'>
               <th>SDK Support</th>
@@ -915,7 +915,7 @@ navigation:
 {% endhighlight %}
           </div>
 
-          <table>
+          <table class="micro">
             <thead>
             <tr class='fill-light'>
               <th>SDK Support</th>

--- a/docs/_generate/item.html
+++ b/docs/_generate/item.html
@@ -59,7 +59,7 @@
     }
   %>
   <div class='space-bottom2'>
-    <table class='fixed'>
+    <table class='micro fixed'>
       <thead>
       <tr class='fill-light'>
         <th>SDK Support</th>


### PR DESCRIPTION
This PR makes the SDK support tables smaller, improving the visual hierarchy of the page. 

cc @tmcw @tristen @mollymerp 
# Default Size (current design)

![screen shot 2016-08-01 at 11 00 32 am](https://cloud.githubusercontent.com/assets/281306/17303883/6f8f4162-57d7-11e6-878d-f2b878445b63.png)
# Micro Size (proposed design)

![screen shot 2016-08-01 at 10 59 39 am](https://cloud.githubusercontent.com/assets/281306/17303886/6fb433f0-57d7-11e6-9172-30bdbc649ece.png)
# Small Size

![screen shot 2016-08-01 at 10 59 58 am](https://cloud.githubusercontent.com/assets/281306/17303884/6fa60988-57d7-11e6-9900-3ad4abe364e7.png)
