### PR TITLE
Line break even if there's not a space

### DIFF
--- a/reference/v8.json
+++ b/reference/v8.json
@@ -899,13 +899,13 @@
         }
       }
     },
-    "text-break-space": {
+    "text-break-all": {
       "type": "boolean",
       "function": "piecewise-constant",
       "zoom-function": true,
       "property-function": true,
       "default": true,
-      "doc": "If true, text will wrap according to text-max-width settings while recognizing spaces. If false, text will wrap according to text-max-width setting with or without spaces. Generally used for non-Latin text",
+      "doc": "If true, text will wrap according to text-max-width settings while recognizing spaces between words. If false, text will wrap according to text-max-width setting with or without spaces. Generally used for non-Latin text",
       "requires": [
         "text-max-width"
       ],

--- a/reference/v8.json
+++ b/reference/v8.json
@@ -899,6 +899,24 @@
         }
       }
     },
+    "text-break-space": {
+      "type": "boolean",
+      "function": "piecewise-constant",
+      "zoom-function": true,
+      "property-function": true,
+      "default": true,
+      "doc": "If true, text will wrap according to text-max-width settings while recognizing spaces. If false, text will wrap according to text-max-width setting with or without spaces. Generally used for non-Latin text",
+      "requires": [
+        "text-max-width"
+      ],
+      "sdk-support": {
+        "basic": {
+          "js": "0.10.0",
+          "ios": "2.0.0",
+          "android": "2.0.1"
+        }
+      }
+    },
     "text-line-height": {
       "type": "number",
       "default": 1.2,


### PR DESCRIPTION
Add an attribute to control the way line breaks happen for CJK languages. `text-break-all` breaks according to a different set of rules. Refs https://github.com/mapbox/mapbox-gl-js/tree/cjk-linebreak

cc @nickidlugash @amyleew 
