### PR TITLE
Ignore layout and paint properties for invalid layers

### DIFF
--- a/lib/validate/validate_layout_property.js
+++ b/lib/validate/validate_layout_property.js
@@ -11,6 +11,8 @@ module.exports = function validateLayoutProperty(options) {
     var propertyKey = options.objectKey;
     var layerSpec = styleSpec['layout_' + options.layerType];
 
+    if (!layerSpec) return [];
+
     if (options.valueSpec || layerSpec[propertyKey]) {
         var errors = [];
 

--- a/lib/validate/validate_paint_property.js
+++ b/lib/validate/validate_paint_property.js
@@ -11,6 +11,8 @@ module.exports = function validatePaintProperty(options) {
     var propertyKey = options.objectKey;
     var layerSpec = styleSpec['paint_' + options.layerType];
 
+    if (!layerSpec) return [];
+
     var transitionMatch = propertyKey.match(/^(.*)-transition$/);
 
     if (transitionMatch && layerSpec[transitionMatch[1]] && layerSpec[transitionMatch[1]].transition) {

--- a/test/fixture/layers.input.json
+++ b/test/fixture/layers.input.json
@@ -81,8 +81,12 @@
       "type": "invalid",
       "source": "vector",
       "source-layer": "source-layer",
-      "layout": {},
-      "paint": {}
+      "layout": {
+        "invalid-size": 42
+      },
+      "paint": {
+        "invalid-color": "red"
+      }
     },
     {
       "id": "missing-source-layer",

--- a/test/fixture/layers.output.json
+++ b/test/fixture/layers.output.json
@@ -61,6 +61,6 @@
   },
   {
     "message": "layers[13]: layer \"missing-source-layer\" must specify a \"source-layer\"",
-    "line": 87
+    "line": 91
   }
 ]


### PR DESCRIPTION
Currently, if a style contains an invalid layer type and either a paint
or layout property for that layer, the style validator will throw.
Instead of throwing, these properties should be ignored, the layer type
will still be reported as an error.
