### PR TITLE
Make SDK support terminology more consistent

### DIFF
--- a/docs/_generate/index.html
+++ b/docs/_generate/index.html
@@ -231,7 +231,7 @@ navigation:
             </thead>
             <tbody>
             <tr>
-              <td>Base support</td>
+              <td>basic functionality</td>
               <td class='center'>&gt;= 0.10.0</td>
               <td class='center'>&gt;= 2.0.0</td>
               <td class='center'>&gt;= 2.0.1</td>
@@ -271,7 +271,7 @@ navigation:
             </thead>
             <tbody>
             <tr>
-              <td>Base support</td>
+              <td>basic functionality</td>
               <td class='center'>&gt;= 0.10.0</td>
               <td class='center'>&gt;= 2.0.0</td>
               <td class='center'>&gt;= 2.0.1</td>
@@ -333,12 +333,12 @@ navigation:
             </thead>
             <tbody>
             <tr>
-              <td>Base support</td>
+              <td>basic functionality</td>
               <td class='center'>&gt;= 0.10.0</td>
               <td class='center'>&gt;= 2.0.0</td>
               <td class='center'>&gt;= 2.0.1</td></tr>
             <tr>
-              <td>Clustering</td>
+              <td>clustering</td>
               <td class='center'>&gt;= 0.14.0</td>
               <td class='center'>Not yet supported</td>
               <td class='center'>Not yet supported</td>
@@ -386,7 +386,7 @@ navigation:
             </thead>
             <tbody>
             <tr>
-              <td>Base support</td>
+              <td>basic functionality</td>
               <td class='center'>&gt;= 0.10.0</td>
               <td class='center'><a href="https://github.com/mapbox/mapbox-gl-native/issues/1350">Not yet supported</a></td>
               <td class='center'><a href="https://github.com/mapbox/mapbox-gl-native/issues/1350">Not yet supported</a></td>
@@ -439,7 +439,7 @@ navigation:
             </thead>
             <tbody>
             <tr>
-              <td>Base support</td>
+              <td>basic functionality</td>
               <td>&gt;= 0.10.0</td>
               <td><a href="https://github.com/mapbox/mapbox-gl-native/issues/601">Not yet supported</a></td>
               <td><a href="https://github.com/mapbox/mapbox-gl-native/issues/601">Not yet supported</a></td>
@@ -960,7 +960,7 @@ navigation:
             </thead>
             <tbody>
             <tr>
-              <td>Base support</td>
+              <td>basic functionality</td>
               <td class='center'>&gt;= 0.10.0</td>
               <td class='center'>&gt;= 2.0.0</td>
               <td class='center'>&gt;= 2.0.1</td>

--- a/docs/_generate/item.html
+++ b/docs/_generate/item.html
@@ -68,29 +68,13 @@
       </tr>
       </thead>
       <tbody>
-      <tr>
-        <td>Base support</td>
-        <td class='center'><%- support('basic', 'js') %></td>
-        <td class='center'><%- support('basic', 'ios') %></td>
-        <td class='center'><%- support('basic', 'android') %></td>
-      </tr>
-      <% if (prop['property-function']) { %>
-      <tr>
-        <td>Data-driven styling</td>
-        <td class='center'><%- support('property-function', 'js') %></td>
-        <td class='center'><%- support('property-function', 'ios') %></td>
-        <td class='center'><%- support('property-function', 'android') %></td>
-      </tr>
-      <% } %>
       <% _.each(Object.keys(prop['sdk-support']), function(key) { %>
-      <% if (['basic', 'property-function'].indexOf(key) < 0) { %>
       <tr>
         <td><%= md(key) %></td>
         <td class='center'><%- support(key, 'js') %></td>
         <td class='center'><%- support(key, 'ios') %></td>
         <td class='center'><%- support(key, 'android') %></td>
       </tr>
-      <% } %>
       <% }); %>
       </tbody>
     </table>

--- a/reference/v8.json
+++ b/reference/v8.json
@@ -328,7 +328,7 @@
       "default": "visible",
       "doc": "The display of this layer. `none` hides this layer.",
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -348,7 +348,7 @@
       "default": "visible",
       "doc": "The display of this layer. `none` hides this layer.",
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -368,7 +368,7 @@
       "default": "visible",
       "doc": "The display of this layer. `none` hides this layer.",
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -390,7 +390,7 @@
       "default": "butt",
       "doc": "The display of line endings.",
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -410,7 +410,7 @@
       "default": "miter",
       "doc": "The display of lines when joining.",
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -430,7 +430,7 @@
         }
       ],
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -450,7 +450,7 @@
         }
       ],
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -468,7 +468,7 @@
       "default": "visible",
       "doc": "The display of this layer. `none` hides this layer.",
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -489,7 +489,7 @@
       "default": "point",
       "doc": "Label placement relative to its geometry. `line` can only be used on LineStrings and Polygons.",
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -511,7 +511,7 @@
         }
       ],
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -526,7 +526,7 @@
       "default": false,
       "doc": "If true, the symbols will not cross tile edges to avoid mutual collisions. Recommended in layers that don't have enough padding in the vector tile to prevent collisions, or if it is a point symbol layer placed after a line symbol layer.",
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -544,7 +544,7 @@
         "icon-image"
       ],
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -562,7 +562,7 @@
         "icon-image"
       ],
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -581,7 +581,7 @@
         "text-field"
       ],
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -604,7 +604,7 @@
         "icon-image"
       ],
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -624,7 +624,7 @@
         "icon-image"
       ],
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -649,7 +649,7 @@
         "text-field"
       ],
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.21.0"
         }
       }
@@ -675,7 +675,7 @@
         "text-field"
       ],
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.21.0"
         }
       }
@@ -688,7 +688,7 @@
       "doc": "A string with {tokens} replaced, referencing the data property to pull from.",
       "tokens": true,
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -708,12 +708,12 @@
         "icon-image"
       ],
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
         },
-        "property-function": {
+        "data-driven styling": {
           "js": "0.21.0"
         }
       }
@@ -731,7 +731,7 @@
         "icon-image"
       ],
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -755,7 +755,7 @@
         }
       ],
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -778,7 +778,7 @@
         "icon-image"
       ],
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -801,7 +801,7 @@
         "text-field"
       ],
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.21.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -825,7 +825,7 @@
         "text-field"
       ],
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -842,7 +842,7 @@
       "tokens": true,
       "doc": "Value to use for a text label. Feature properties are specified using tokens like {field_name}.",
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -861,7 +861,7 @@
         "text-field"
       ],
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -881,7 +881,7 @@
         "text-field"
       ],
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -901,7 +901,7 @@
         "text-field"
       ],
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -920,7 +920,7 @@
         "text-field"
       ],
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -939,7 +939,7 @@
         "text-field"
       ],
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -962,7 +962,7 @@
         "text-field"
       ],
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -991,7 +991,7 @@
         "text-field"
       ],
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -1013,7 +1013,7 @@
         }
       ],
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -1033,7 +1033,7 @@
         "text-field"
       ],
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -1053,7 +1053,7 @@
         "text-field"
       ],
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -1077,7 +1077,7 @@
         }
       ],
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -1100,7 +1100,7 @@
         "text-field"
       ],
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -1124,7 +1124,7 @@
         "text-field"
       ],
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -1142,7 +1142,7 @@
         "text-field"
       ],
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -1160,7 +1160,7 @@
         "text-field"
       ],
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -1179,7 +1179,7 @@
         "icon-image"
       ],
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -1197,7 +1197,7 @@
       "default": "visible",
       "doc": "The display of this layer. `none` hides this layer.",
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -1217,7 +1217,7 @@
       "default": "visible",
       "doc": "The display of this layer. `none` hides this layer.",
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -1326,7 +1326,7 @@
       "default": true,
       "doc": "Whether or not the fill should be antialiased.",
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -1344,12 +1344,12 @@
       "doc": "The opacity of the entire fill layer. In contrast to the fill-color, this value will also affect the 1px stroke around the fill, if the stroke is used.",
       "transition": true,
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
         },
-        "property-function": {
+        "data-driven styling": {
           "js": "0.21.0"
         }
       }
@@ -1368,12 +1368,12 @@
         }
       ],
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
         },
-        "property-function": {
+        "data-driven styling": {
           "js": "0.19.0"
         }
       }
@@ -1394,12 +1394,12 @@
         }
       ],
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
         },
-        "property-function": {
+        "data-driven styling": {
           "js": "0.19.0"
         }
       }
@@ -1419,7 +1419,7 @@
       "units": "pixels",
       "doc": "The geometry's offset. Values are [x, y] where negatives indicate left and up, respectively.",
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -1441,7 +1441,7 @@
         "fill-translate"
       ],
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -1456,7 +1456,7 @@
       "transition": true,
       "doc": "Name of image in sprite to use for drawing image fills. For seamless patterns, image width and height must be a factor of two (2, 4, 8, ..., 512).",
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -1476,7 +1476,7 @@
       "maximum": 1,
       "transition": true,
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -1497,12 +1497,12 @@
         }
       ],
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
         },
-        "property-function": {
+        "data-driven styling": {
           "js": "0.23.0"
         }
       }
@@ -1522,7 +1522,7 @@
       "units": "pixels",
       "doc": "The geometry's offset. Values are [x, y] where negatives indicate left and up, respectively.",
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -1544,7 +1544,7 @@
         "line-translate"
       ],
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -1562,7 +1562,7 @@
       "units": "pixels",
       "doc": "Stroke thickness.",
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -1580,7 +1580,7 @@
       "transition": true,
       "units": "pixels",
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -1597,7 +1597,7 @@
       "transition": true,
       "units": "pixels",
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.12.1",
           "ios": "3.1.0",
           "android": "3.0.0"
@@ -1615,7 +1615,7 @@
       "units": "pixels",
       "doc": "Blur applied to the line, in pixels.",
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -1638,7 +1638,7 @@
         }
       ],
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -1653,7 +1653,7 @@
       "transition": true,
       "doc": "Name of image in sprite to use for drawing image lines. For seamless patterns, image width must be a factor of two (2, 4, 8, ..., 512).",
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -1673,12 +1673,12 @@
       "units": "pixels",
       "doc": "Circle radius.",
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
         },
-        "property-function": {
+        "data-driven styling": {
           "js": "0.18.0"
         }
       }
@@ -1692,12 +1692,12 @@
       "property-function": true,
       "transition": true,
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
         },
-        "property-function": {
+        "data-driven styling": {
           "js": "0.18.0"
         }
       }
@@ -1711,12 +1711,12 @@
       "property-function": true,
       "transition": true,
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
         },
-        "property-function": {
+        "data-driven styling": {
           "js": "0.20.0"
         }
       }
@@ -1732,12 +1732,12 @@
       "property-function": true,
       "transition": true,
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
         },
-        "property-function": {
+        "data-driven styling": {
           "js": "0.20.0"
         }
       }
@@ -1754,7 +1754,7 @@
       "units": "pixels",
       "doc": "The geometry's offset. Values are [x, y] where negatives indicate left and up, respectively.",
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -1776,7 +1776,7 @@
         "circle-translate"
       ],
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -1795,7 +1795,7 @@
       "default": "map",
       "doc": "Controls the scaling behavior of the circle when the map is pitched. The value `map` scales circles according to their apparent distance to the camera. The value `viewport` results in no pitch-related scaling.",
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.21.0"
         }
       }
@@ -1816,7 +1816,7 @@
         "icon-image"
       ],
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -1835,7 +1835,7 @@
         "icon-image"
       ],
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -1854,7 +1854,7 @@
         "icon-image"
       ],
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -1875,7 +1875,7 @@
         "icon-image"
       ],
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -1896,7 +1896,7 @@
         "icon-image"
       ],
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -1921,7 +1921,7 @@
         "icon-image"
       ],
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -1944,7 +1944,7 @@
         "icon-translate"
       ],
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -1965,7 +1965,7 @@
         "text-field"
       ],
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -1984,7 +1984,7 @@
         "text-field"
       ],
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -2003,7 +2003,7 @@
         "text-field"
       ],
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -2024,7 +2024,7 @@
         "text-field"
       ],
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -2045,7 +2045,7 @@
         "text-field"
       ],
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -2070,7 +2070,7 @@
         "text-field"
       ],
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -2093,7 +2093,7 @@
         "text-translate"
       ],
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -2112,7 +2112,7 @@
       "zoom-function": true,
       "transition": true,
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -2129,7 +2129,7 @@
       "units": "degrees",
       "doc": "Rotates hues around the color wheel.",
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -2146,7 +2146,7 @@
       "maximum": 1,
       "transition": true,
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -2163,7 +2163,7 @@
       "maximum": 1,
       "transition": true,
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -2180,7 +2180,7 @@
       "zoom-function": true,
       "transition": true,
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -2197,7 +2197,7 @@
       "zoom-function": true,
       "transition": true,
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -2214,7 +2214,7 @@
       "units": "milliseconds",
       "doc": "Fade duration when a new tile is added.",
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -2236,7 +2236,7 @@
         }
       ],
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -2250,7 +2250,7 @@
       "transition": true,
       "doc": "Name of image in sprite to use for drawing an image background. For seamless patterns, image width and height must be a factor of two (2, 4, 8, ..., 512).",
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"
@@ -2267,7 +2267,7 @@
       "zoom-function": true,
       "transition": true,
       "sdk-support": {
-        "basic": {
+        "basic functionality": {
           "js": "0.10.0",
           "ios": "2.0.0",
           "android": "2.0.1"


### PR DESCRIPTION
This PR makes SDK support terminology more consistent. All terms complete the sentence "The SDK supports ____"). 

This PR also eliminates presentational renaming of SDK support terminology (i.e. `property-function` -> `data-driven styling`). This makes the codebase less surprising. Although the strings are human-readable we should treat their modification as a breaking API change because they may be relied upon by external software.

resolves #498 
related to https://github.com/mapbox/mapbox-gl-style-spec/pull/465#discussion-diff-69342567

![screen shot 2016-09-20 at 4 47 33 pm](https://cloud.githubusercontent.com/assets/281306/18692857/160056de-7f52-11e6-903c-e29b21094178.png)
![screen shot 2016-09-20 at 4 49 31 pm](https://cloud.githubusercontent.com/assets/281306/18692877/3c1e4678-7f52-11e6-9970-4b9248c2c63b.png)

cc @jfirebaugh @boundsj @lbud @mollymerp @mapsam 
