### PR TITLE
Clarify icon-text-fit-padding's icon-text-fit requirement

### DIFF
--- a/docs/_generate/item.html
+++ b/docs/_generate/item.html
@@ -32,7 +32,11 @@
             if (req['!']) {
               return '<em>Disabled by</em> <var>' + req['!'] + '</var>.';
             } else {
-              return '<em>Requires</em> <var>' + _.toPairs(req)[0][0] + ' = ' + _.toPairs(req)[0][1] + '</var>.';
+              var requiredValue = _.toPairs(req)[0][1];
+              var requiredDisplay = _.isArray(requiredValue)
+                ? '</var>one of<var> ' + requiredValue.join('</var>,<var> ')
+                : requiredValue;
+              return '<em>Requires</em> <var>' + _.toPairs(req)[0][0] + ' = ' + requiredDisplay + '</var>.';
             }
           }
         }).join(' ') %>

--- a/reference/v8.json
+++ b/reference/v8.json
@@ -674,8 +674,14 @@
       "doc": "Size of padding area around the text-fit size in clockwise order: top, right, bottom, left.",
       "requires": [
         "icon-image",
-        "icon-text-fit",
-        "text-field"
+        "text-field",
+        {
+          "icon-text-fit": [
+            "both",
+            "width",
+            "height"
+          ]
+        }
       ],
       "sdk-support": {
         "basic functionality": {


### PR DESCRIPTION
Closes #504.
- Specifies the particular `icon-text-fit` values that are required by `icon-text-fit-padding`, introducing a new possibility for the `requires` property:  arrays as required property values.
- Modifies doc generation code to accommodate the above.

This template code renders like so:

![screen shot 2016-09-23 at 12 05 59 pm](https://cloud.githubusercontent.com/assets/628431/18798283/98d2db1e-8186-11e6-925c-503a33c78c08.png)
