### PR TITLE
clarify fill, not stroke, color for circle

### DIFF
--- a/reference/v8.json
+++ b/reference/v8.json
@@ -1689,7 +1689,7 @@
     "circle-color": {
       "type": "color",
       "default": "#000000",
-      "doc": "The color of the circle.",
+      "doc": "The fill color of the circle.",
       "function": "interpolated",
       "zoom-function": true,
       "property-function": true,


### PR DESCRIPTION
Very minor, but until you try it, it's not obvious that `circle-color` refers to the fill color, not the stroke color, of the circle. 
