### PR TITLE
Omit commas from source types

### DIFF
--- a/docs/_generate/index.html
+++ b/docs/_generate/index.html
@@ -134,7 +134,7 @@ navigation:
       <h2><a href='#sources' title='link to sources'>Sources</a></h2>
       <p>
         Sources supply data to be shown on the map. The type of source is specified by the <code>"type"</code> property,
-        and must be one of <var><%= source_types.join(', ') %></var>. Adding a source
+        and must be one of <var><%= source_types.join('</var>, <var>') %></var>. Adding a source
         won't immediately make data appear on the map because sources don't contain
         styling details like color or width. Layers refer
         to a source and give it a visual representation. This makes it possible


### PR DESCRIPTION
From:

> The type of source is specified by the `"type"` property, and must be one of _vector, raster, geojson, image, video_.

to:

> The type of source is specified by the `"type"` property, and must be one of _vector_, _raster_, _geojson_, _image_, _video_.

The `<var>` tags now surround each individual source type instead of the entire list. #nitpicky-english

<img width="316" alt="list" src="https://cloud.githubusercontent.com/assets/1231218/18938463/8dded480-85ad-11e6-8d88-6fea7f364957.png">

/cc @jfirebaugh
