### PR TITLE
Fix mistake during release of 8.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## master
 
+## 8.9.0
+
+v8.0.0 styles are fully compatible with v8.9.0.
+
+* Added identity functions
+* Added `auto` value which represents the calculated default value
+
 ## 8.8.1
 
 v8.0.0 styles are fully compatible with v8.8.1.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mapbox-gl-style-spec",
   "description": "a specification for mapbox gl styles",
-  "version": "8.8.1",
+  "version": "8.9.0",
   "author": "Mapbox",
   "bin": {
     "gl-style-migrate": "bin/gl-style-migrate",


### PR DESCRIPTION
I accidentally published the `HEAD` of the `identity-function` branch
to `npm` as version `8.9.0` in
https://github.com/mapbox/mapbox-gl-style-spec/commit/d7975ae0f6e9da2cd5
67c8172fe7867f204509a3. Fortunately, I did merge `identity-function`
into `master` first. With this commit restoring some state in
`mb-pages`, we should be able to continue forward without ill effect.

cc @tmcw @mollymerp @mapsam 
