### PR TITLE
Define a clear order of operations for object element validation, remove "allowArbitraryKeys" option

### DIFF
--- a/lib/validate/validate_layer.js
+++ b/lib/validate/validate_layer.js
@@ -74,8 +74,10 @@ module.exports = function validateLayer(options) {
         valueSpec: styleSpec.layer,
         style: options.style,
         styleSpec: options.styleSpec,
-        allowArbitraryKeys: true,
         objectElementValidators: {
+            '*': function() {
+                return [];
+            },
             filter: validateFilter,
             layout: function(options) {
                 return validateObject({

--- a/lib/validate/validate_object.js
+++ b/lib/validate/validate_object.js
@@ -7,8 +7,8 @@ var validate = require('./validate');
 module.exports = function validateObject(options) {
     var key = options.key;
     var object = options.value;
-    var valueSpec = options.valueSpec;
-    var objectElementValidators = options.objectElementValidators || {};
+    var elementSpecs = options.valueSpec || {};
+    var elementValidators = options.objectElementValidators || {};
     var style = options.style;
     var styleSpec = options.styleSpec;
     var errors = [];
@@ -19,30 +19,37 @@ module.exports = function validateObject(options) {
     }
 
     for (var objectKey in object) {
-        var valueSpecKey = objectKey.split('.')[0]; // treat 'paint.*' as 'paint'
-        var objectElementSpec = valueSpec && (valueSpec[valueSpecKey] || valueSpec['*']);
-        var objectElementValidator = objectElementValidators[valueSpecKey] || objectElementValidators['*'];
+        var elementSpecKey = objectKey.split('.')[0]; // treat 'paint.*' as 'paint'
+        var elementSpec = elementSpecs[elementSpecKey] || elementSpecs['*'];
 
-        if (objectElementSpec || objectElementValidator) {
-            errors = errors.concat((objectElementValidator || validate)({
-                key: (key ? key + '.' : key) + objectKey,
-                value: object[objectKey],
-                valueSpec: objectElementSpec,
-                style: style,
-                styleSpec: styleSpec,
-                object: object,
-                objectKey: objectKey
-            }));
-
-        // tolerate root-level extra keys & arbitrary layer properties
-        } else if (key !== '' && !options.allowArbitraryKeys) {
+        var validateElement;
+        if (elementValidators[elementSpecKey]) {
+            validateElement = elementValidators[elementSpecKey];
+        } else if (elementSpecs[elementSpecKey]) {
+            validateElement = validate;
+        } else if (elementValidators['*']) {
+            validateElement = elementValidators['*'];
+        } else if (elementSpecs['*']) {
+            validateElement = validate;
+        } else {
             errors.push(new ValidationError(key, object[objectKey], 'unknown property "%s"', objectKey));
+            continue;
         }
+
+        errors = errors.concat(validateElement({
+            key: (key ? key + '.' : key) + objectKey,
+            value: object[objectKey],
+            valueSpec: elementSpec,
+            style: style,
+            styleSpec: styleSpec,
+            object: object,
+            objectKey: objectKey
+        }));
     }
 
-    for (valueSpecKey in valueSpec) {
-        if (valueSpec[valueSpecKey].required && valueSpec[valueSpecKey]['default'] === undefined && object[valueSpecKey] === undefined) {
-            errors.push(new ValidationError(key, object, 'missing required property "%s"', valueSpecKey));
+    for (elementSpecKey in elementSpecs) {
+        if (elementSpecs[elementSpecKey].required && elementSpecs[elementSpecKey]['default'] === undefined && object[elementSpecKey] === undefined) {
+            errors.push(new ValidationError(key, object, 'missing required property "%s"', elementSpecKey));
         }
     }
 

--- a/lib/validate/validate_object.js
+++ b/lib/validate/validate_object.js
@@ -2,7 +2,7 @@
 
 var ValidationError = require('../error/validation_error');
 var getType = require('../util/get_type');
-var validate = require('./validate');
+var validateSpec = require('./validate');
 
 module.exports = function validateObject(options) {
     var key = options.key;
@@ -26,11 +26,11 @@ module.exports = function validateObject(options) {
         if (elementValidators[elementSpecKey]) {
             validateElement = elementValidators[elementSpecKey];
         } else if (elementSpecs[elementSpecKey]) {
-            validateElement = validate;
+            validateElement = validateSpec;
         } else if (elementValidators['*']) {
             validateElement = elementValidators['*'];
         } else if (elementSpecs['*']) {
-            validateElement = validate;
+            validateElement = validateSpec;
         } else {
             errors.push(new ValidationError(key, object[objectKey], 'unknown property "%s"', objectKey));
             continue;

--- a/lib/validate_style.min.js
+++ b/lib/validate_style.min.js
@@ -31,9 +31,11 @@ function validateStyleMin(style, styleSpec) {
         styleSpec: styleSpec,
         style: style,
         objectElementValidators: {
-            glyphs: validateGlyphsURL
-        },
-        allowArbitraryKeys: true
+            glyphs: validateGlyphsURL,
+            '*': function() {
+                return [];
+            }
+        }
     }));
 
     if (styleSpec.$version > 7 && style.constants) {


### PR DESCRIPTION
This PR refactors `validateObject` such that

 - the order of precedence for object element validation logic is more intuitive and useful:
   1. a specific object element validator
   2. a specific object element specification
   3. a wildcard object element validator
   4. a wildcard object element specification
   5. error!
 - the `allowArbitraryKeys` option is rolled into the above logic (case "v" ☝️)
 - internal variable names are more consistent, giving better contextual clues to readers about how the function works

cc @lbud @jfirebaugh 