### PR TITLE
Eliminate fill-extrusion-base's special case "requires" value

### DIFF
--- a/reference/v8.json
+++ b/reference/v8.json
@@ -1902,12 +1902,10 @@
       "default": 0,
       "minimum": 0,
       "units": "meters",
-      "doc": "The height with which to extrude the base of this layer.",
+      "doc": "The height with which to extrude the base of this layer. Must be less than or equal to `fill-extrusion-height`.",
       "transition": true,
       "requires": [
-        {
-          "<=": "fill-extrusion-height"
-        }
+        "fill-extrusion-height"
       ],
       "sdk-support": {
         "basic functionality": {


### PR DESCRIPTION
The code generator in mapbox-gl-native doesn't know how to deal with the `"<="` key. Since no other `requires` values use comparison operators, and this comparison can't in most cases be enforced because the actual values will come from source data, I think it's better to note this restriction in prose documentation instead.