### PR TITLE
Indicate macOS SDK support

### DIFF
--- a/docs/_generate/index.html
+++ b/docs/_generate/index.html
@@ -105,10 +105,11 @@ navigation:
       <p>The intended audience of this specification includes:
       <ul>
       <li>Advanced designers and cartographers who want to write styles by hand rather than use <a href='https://www.mapbox.com/studio'>Mapbox Studio</a></li>
-      <li>Developers using style-related features of <a href='https://www.mapbox.com/mapbox-gl-js/'>Mapbox GL JS</a> or the Mapbox <a href='https://www.mapbox.com/ios-sdk/'>iOS</a> or <a href='https://www.mapbox.com/android-sdk/'>Android</a> SDKs</li>
+      <li>Developers using style-related features of <a href='https://www.mapbox.com/mapbox-gl-js/'>Mapbox GL JS</a> or the <a href='https://www.mapbox.com/android-sdk/'>Mapbox Android SDK</a></li>
       <li>Authors of software that generates or processes Mapbox styles.</li>
       </ul>
       </p>
+      <p>Developers using the <a href='https://www.mapbox.com/ios-sdk/'>Mapbox iOS SDK</a> or <a href='https://github.com/mapbox/mapbox-gl-native/tree/master/platform/macos/'>Mapbox macOS SDK</a> should consult the <a href="https://www.mapbox.com/ios-sdk/api/3.4.0-beta.6/">iOS SDK API reference</a> for platform-appropriate documentation of style-related features.</p>
     </div>
 
     <div class='prose'>
@@ -208,7 +209,7 @@ navigation:
           EPSG:3857 (or EPSG:900913) as a source of tiled data.
           The server url should contain a <code>"{bbox-epsg-3857}"</code>
           replacement token to supply the <code>bbox</code> parameter.
-          <em>(This feature is not yet supported by the Mapbox iOS SDK.)</em>
+          <em>(This feature is not yet supported by the Mapbox iOS SDK or Mapbox macOS SDK.)</em>
 {% highlight json%}
 "wms-imagery": {
   "type": "raster",
@@ -254,16 +255,18 @@ navigation:
             <tr class='fill-light'>
               <th>SDK Support</th>
               <td class='center'>Mapbox GL JS</td>
-              <td class='center'>iOS SDK</td>
               <td class='center'>Android SDK</td>
+              <td class='center'>iOS SDK</td>
+              <td class='center'>macOS SDK</td>
             </tr>
             </thead>
             <tbody>
             <tr>
               <td>basic functionality</td>
               <td class='center'>&gt;= 0.10.0</td>
-              <td class='center'>&gt;= 2.0.0</td>
               <td class='center'>&gt;= 2.0.1</td>
+              <td class='center'>&gt;= 2.0.0</td>
+              <td class='center'>&gt;= 0.1.0</td>
             </tr>
             </tbody>
           </table>
@@ -294,16 +297,18 @@ navigation:
             <tr class='fill-light'>
               <th>SDK Support</th>
               <td class='center'>Mapbox GL JS</td>
-              <td class='center'>iOS SDK</td>
               <td class='center'>Android SDK</td>
+              <td class='center'>iOS SDK</td>
+              <td class='center'>macOS SDK</td>
             </tr>
             </thead>
             <tbody>
             <tr>
               <td>basic functionality</td>
               <td class='center'>&gt;= 0.10.0</td>
-              <td class='center'>&gt;= 2.0.0</td>
               <td class='center'>&gt;= 2.0.1</td>
+              <td class='center'>&gt;= 2.0.0</td>
+              <td class='center'>&gt;= 0.1.0</td>
             </tr>
             </tbody>
           </table>
@@ -356,21 +361,25 @@ navigation:
             <tr class='fill-light'>
               <th>SDK Requirements</th>
               <td class='center'>Mapbox GL JS</td>
-              <td class='center'>iOS SDK</td>
               <td class='center'>Android SDK</td>
+              <td class='center'>iOS SDK</td>
+              <td class='center'>macOS SDK</td>
             </tr>
             </thead>
             <tbody>
             <tr>
               <td>basic functionality</td>
               <td class='center'>&gt;= 0.10.0</td>
+              <td class='center'>&gt;= 2.0.1</td>
               <td class='center'>&gt;= 2.0.0</td>
-              <td class='center'>&gt;= 2.0.1</td></tr>
+              <td class='center'>&gt;= 0.1.0</td>
+            </tr>
             <tr>
               <td>clustering</td>
               <td class='center'>&gt;= 0.14.0</td>
-              <td class='center'>Not yet supported</td>
               <td class='center'>&gt;= 4.2.0</td>
+              <td class='center'>Not yet supported</td>
+              <td class='center'>Not yet supported</td>
             </tr>
             </tbody>
           </table>
@@ -409,14 +418,16 @@ navigation:
             <tr class='fill-light'>
               <th>SDK Support</th>
               <td class='center'>Mapbox GL JS</td>
-              <td class='center'>iOS SDK</td>
               <td class='center'>Android SDK</td>
+              <td class='center'>iOS SDK</td>
+              <td class='center'>macOS SDK</td>
             </tr>
             </thead>
             <tbody>
             <tr>
               <td>basic functionality</td>
               <td class='center'>&gt;= 0.10.0</td>
+              <td class='center'><a href="https://github.com/mapbox/mapbox-gl-native/issues/1350">Not yet supported</a></td>
               <td class='center'><a href="https://github.com/mapbox/mapbox-gl-native/issues/1350">Not yet supported</a></td>
               <td class='center'><a href="https://github.com/mapbox/mapbox-gl-native/issues/1350">Not yet supported</a></td>
             </tr>
@@ -462,14 +473,16 @@ navigation:
             <tr class='fill-light'>
               <th>SDK Support</th>
               <td class='center'>Mapbox GL JS</td>
-              <td class='center'>iOS SDK</td>
               <td class='center'>Android SDK</td>
+              <td class='center'>iOS SDK</td>
+              <td class='center'>macOS SDK</td>
             </tr>
             </thead>
             <tbody>
             <tr>
               <td>basic functionality</td>
               <td>&gt;= 0.10.0</td>
+              <td><a href="https://github.com/mapbox/mapbox-gl-native/issues/601">Not yet supported</a></td>
               <td><a href="https://github.com/mapbox/mapbox-gl-native/issues/601">Not yet supported</a></td>
               <td><a href="https://github.com/mapbox/mapbox-gl-native/issues/601">Not yet supported</a></td>
             </tr>
@@ -803,26 +816,30 @@ navigation:
             <tr class='fill-light'>
               <th>SDK Support</th>
               <td class='center'>Mapbox GL JS</td>
-              <td class='center'>iOS SDK</td>
               <td class='center'>Android SDK</td>
+              <td class='center'>iOS SDK</td>
+              <td class='center'>macOS SDK</td>
             </tr>
             </thead>
             <tbody>
             <tr>
               <td>basic functionality</td>
               <td class='center'>&gt;= 0.10.0</td>
-              <td class='center'>&gt;= 2.0.0</td>
               <td class='center'>&gt;= 2.0.1</td>
+              <td class='center'>&gt;= 2.0.0</td>
+              <td class='center'>&gt;= 0.1.0</td>
             </tr>
             <tr>
               <td><code>identity</code> type</td>
               <td class='center'>&gt;= 0.26.0</td>
               <td class='center'>Not yet supported</td>
               <td class='center'>Not yet supported</td>
+              <td class='center'>Not yet supported</td>
             </tr>
             <tr>
               <td><code>colorSpace</code></td>
               <td class='center'>&gt;= 0.26.0</td>
+              <td class='center'>Not yet supported</td>
               <td class='center'>Not yet supported</td>
               <td class='center'>Not yet supported</td>
             </tr>
@@ -1032,22 +1049,25 @@ navigation:
             <tr class='fill-light'>
               <th>SDK Support</th>
               <td class='center'>Mapbox GL JS</td>
-              <td class='center'>iOS SDK</td>
               <td class='center'>Android SDK</td>
+              <td class='center'>iOS SDK</td>
+              <td class='center'>macOS SDK</td>
             </tr>
             </thead>
             <tbody>
             <tr>
               <td>basic functionality</td>
               <td class='center'>&gt;= 0.10.0</td>
-              <td class='center'>&gt;= 2.0.0</td>
               <td class='center'>&gt;= 2.0.1</td>
+              <td class='center'>&gt;= 2.0.0</td>
+              <td class='center'>&gt;= 0.1.0</td>
             </tr>
             <tr>
               <td><code>has</code>/<code>!has</code></td>
               <td class='center'>&gt;= 0.19.0</td>
-              <td class='center'>&gt;= 3.3.0</td>
               <td class='center'>&gt;= 4.1.0</td>
+              <td class='center'>&gt;= 3.3.0</td>
+              <td class='center'>&gt;= 0.1.0</td>
             </tr>
             </tbody>
           </table>

--- a/docs/_generate/index.html
+++ b/docs/_generate/index.html
@@ -209,7 +209,7 @@ navigation:
           EPSG:3857 (or EPSG:900913) as a source of tiled data.
           The server url should contain a <code>"{bbox-epsg-3857}"</code>
           replacement token to supply the <code>bbox</code> parameter.
-          <em>(This feature is not yet supported by the Mapbox iOS SDK or Mapbox macOS SDK.)</em>
+          <em>(This feature is not yet supported by the Mapbox iOS SDK.)</em>
 {% highlight json%}
 "wms-imagery": {
   "type": "raster",

--- a/docs/_generate/index.html
+++ b/docs/_generate/index.html
@@ -109,7 +109,7 @@ navigation:
       <li>Authors of software that generates or processes Mapbox styles.</li>
       </ul>
       </p>
-      <p>Developers using the <a href='https://www.mapbox.com/ios-sdk/'>Mapbox iOS SDK</a> or <a href='https://github.com/mapbox/mapbox-gl-native/tree/master/platform/macos/'>Mapbox macOS SDK</a> should consult the <a href="https://www.mapbox.com/ios-sdk/api/3.4.0-beta.6/">iOS SDK API reference</a> for platform-appropriate documentation of style-related features.</p>
+      <p>Developers using the <a href='https://www.mapbox.com/ios-sdk/'>Mapbox iOS SDK</a> or <a href='https://github.com/mapbox/mapbox-gl-native/tree/master/platform/macos/'>Mapbox macOS SDK</a> should consult the iOS SDK API reference for platform-appropriate documentation of style-related features.</p>
     </div>
 
     <div class='prose'>

--- a/docs/_generate/item.html
+++ b/docs/_generate/item.html
@@ -75,8 +75,9 @@
       <tr class='fill-light'>
         <th>SDK Support</th>
         <td class='center'>Mapbox GL JS</td>
-        <td class='center'>iOS SDK</td>
         <td class='center'>Android SDK</td>
+        <td class='center'>iOS SDK</td>
+        <td class='center'>macOS SDK</td>
       </tr>
       </thead>
       <tbody>
@@ -84,8 +85,9 @@
       <tr>
         <td><%= md(key) %></td>
         <td class='center'><%- support(key, 'js') %></td>
-        <td class='center'><%- support(key, 'ios') %></td>
         <td class='center'><%- support(key, 'android') %></td>
+        <td class='center'><%- support(key, 'ios') %></td>
+        <td class='center'><%- support(key, 'macos') %></td>
       </tr>
       <% }); %>
       </tbody>

--- a/reference/v8.json
+++ b/reference/v8.json
@@ -801,7 +801,8 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.21.0",
-          "android": "4.2.0"
+          "android": "4.2.0",
+          "macos": "0.2.1"
         }
       }
     },
@@ -833,7 +834,8 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.21.0",
-          "android": "4.2.0"
+          "android": "4.2.0",
+          "macos": "0.2.1"
         }
       }
     },
@@ -970,7 +972,8 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.21.0",
-          "android": "4.2.0"
+          "android": "4.2.0",
+          "macos": "0.2.1"
         },
         "`auto` value": {
           "js": "0.25.0",
@@ -2300,7 +2303,8 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.21.0",
-          "android": "4.2.0"
+          "android": "4.2.0",
+          "macos": "0.2.1"
         }
       }
     },

--- a/reference/v8.json
+++ b/reference/v8.json
@@ -276,8 +276,9 @@
           "sdk-support": {
             "basic functionality": {
               "js": "0.10.0",
+              "android": "2.0.1",
               "ios": "2.0.0",
-              "android": "2.0.1"
+              "macos": "0.1.0"
             }
           }
         },
@@ -286,8 +287,9 @@
           "sdk-support": {
             "basic functionality": {
               "js": "0.10.0",
+              "android": "2.0.1",
               "ios": "2.0.0",
-              "android": "2.0.1"
+              "macos": "0.1.0"
             }
           }
         },
@@ -296,8 +298,9 @@
           "sdk-support": {
             "basic functionality": {
               "js": "0.10.0",
+              "android": "2.0.1",
               "ios": "2.0.0",
-              "android": "2.0.1"
+              "macos": "0.1.0"
             }
           }
         },
@@ -306,8 +309,9 @@
           "sdk-support": {
             "basic functionality": {
               "js": "0.10.0",
+              "android": "2.0.1",
               "ios": "2.0.0",
-              "android": "2.0.1"
+              "macos": "0.1.0"
             }
           }
         },
@@ -324,8 +328,9 @@
           "sdk-support": {
             "basic functionality": {
               "js": "0.10.0",
+              "android": "2.0.1",
               "ios": "2.0.0",
-              "android": "2.0.1"
+              "macos": "0.1.0"
             }
           }
         },
@@ -334,8 +339,9 @@
           "sdk-support": {
             "basic functionality": {
               "js": "0.10.0",
+              "android": "2.0.1",
               "ios": "2.0.0",
-              "android": "2.0.1"
+              "macos": "0.1.0"
             }
           }
         }
@@ -412,8 +418,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         }
       }
     }
@@ -434,8 +441,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         }
       }
     }
@@ -456,8 +464,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         }
       }
     }
@@ -503,8 +512,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         }
       }
     },
@@ -528,8 +538,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         }
       }
     },
@@ -547,8 +558,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         }
       }
     },
@@ -566,8 +578,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         }
       }
     },
@@ -586,8 +599,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         }
       }
     }
@@ -610,8 +624,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         }
       }
     },
@@ -631,8 +646,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         }
       }
     },
@@ -645,8 +661,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         }
       }
     },
@@ -662,8 +679,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         }
       }
     },
@@ -679,8 +697,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         }
       }
     },
@@ -697,8 +716,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         }
       }
     },
@@ -725,8 +745,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         },
         "`auto` value": {
           "js": "0.25.0",
@@ -747,8 +768,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         }
       }
     },
@@ -824,8 +846,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         }
       }
     },
@@ -844,8 +867,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         },
         "data-driven styling": {
           "js": "0.21.0"
@@ -866,8 +890,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         }
       }
     },
@@ -889,8 +914,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         }
       }
     },
@@ -912,8 +938,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         },
         "data-driven styling": {
           "js": "0.29.0"
@@ -974,8 +1001,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         },
         "`auto` value": {
           "js": "0.25.0",
@@ -993,8 +1021,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         }
       }
     },
@@ -1011,8 +1040,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         }
       }
     },
@@ -1030,8 +1060,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         }
       }
     },
@@ -1049,8 +1080,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         }
       }
     },
@@ -1067,8 +1099,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         }
       }
     },
@@ -1085,8 +1118,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         }
       }
     },
@@ -1113,8 +1147,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         }
       }
     },
@@ -1159,8 +1194,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         }
       }
     },
@@ -1180,8 +1216,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         }
       }
     },
@@ -1199,8 +1236,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         }
       }
     },
@@ -1218,8 +1256,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         }
       }
     },
@@ -1241,8 +1280,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         }
       }
     },
@@ -1269,8 +1309,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         }
       }
     },
@@ -1292,8 +1333,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         }
       }
     },
@@ -1309,8 +1351,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         }
       }
     },
@@ -1326,8 +1369,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         }
       }
     },
@@ -1344,8 +1388,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         }
       }
     },
@@ -1364,8 +1409,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         }
       }
     }
@@ -1386,8 +1432,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         }
       }
     }
@@ -1609,8 +1656,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         }
       }
     },
@@ -1627,8 +1675,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         },
         "data-driven styling": {
           "js": "0.21.0"
@@ -1651,8 +1700,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         },
         "data-driven styling": {
           "js": "0.19.0"
@@ -1677,8 +1727,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         },
         "data-driven styling": {
           "js": "0.19.0"
@@ -1701,8 +1752,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         }
       }
     },
@@ -1726,8 +1778,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         }
       }
     },
@@ -1740,8 +1793,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         }
       }
     }
@@ -1895,8 +1949,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         },
         "data-driven styling": {
           "js": "0.29.0"
@@ -1919,8 +1974,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         },
         "data-driven styling": {
           "js": "0.23.0"
@@ -1943,8 +1999,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         }
       }
     },
@@ -1968,8 +2025,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         }
       }
     },
@@ -1985,8 +2043,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         }
       }
     },
@@ -2003,8 +2062,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         },
         "data-driven styling": {
             "js": "0.29.0"
@@ -2023,8 +2083,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.12.1",
+          "android": "3.0.0",
           "ios": "3.1.0",
-          "android": "3.0.0"
+          "macos": "0.1.0"
         },
         "data-driven styling": {
           "js": "0.29.0"
@@ -2044,8 +2105,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         },
         "data-driven styling": {
           "js": "0.29.0"
@@ -2069,8 +2131,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         }
       }
     },
@@ -2083,8 +2146,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         }
       }
     }
@@ -2103,8 +2167,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         },
         "data-driven styling": {
           "js": "0.18.0"
@@ -2122,8 +2187,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         },
         "data-driven styling": {
           "js": "0.18.0"
@@ -2141,8 +2207,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         },
         "data-driven styling": {
           "js": "0.20.0"
@@ -2162,8 +2229,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         },
         "data-driven styling": {
           "js": "0.20.0"
@@ -2183,8 +2251,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         }
       }
     },
@@ -2208,8 +2277,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         }
       }
     },
@@ -2306,8 +2376,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         }
       }
     },
@@ -2324,8 +2395,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         }
       }
     },
@@ -2342,8 +2414,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         }
       }
     },
@@ -2362,8 +2435,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         }
       }
     },
@@ -2382,8 +2456,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         }
       }
     },
@@ -2406,8 +2481,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         }
       }
     },
@@ -2432,8 +2508,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         }
       }
     },
@@ -2452,8 +2529,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         }
       }
     },
@@ -2470,8 +2548,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         }
       }
     },
@@ -2488,8 +2567,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         }
       }
     },
@@ -2508,8 +2588,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         }
       }
     },
@@ -2528,8 +2609,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         }
       }
     },
@@ -2552,8 +2634,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         }
       }
     },
@@ -2578,8 +2661,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         }
       }
     }
@@ -2597,8 +2681,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         }
       }
     },
@@ -2614,8 +2699,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         }
       }
     },
@@ -2631,8 +2717,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         }
       }
     },
@@ -2648,8 +2735,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         }
       }
     },
@@ -2665,8 +2753,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         }
       }
     },
@@ -2682,8 +2771,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         }
       }
     },
@@ -2699,8 +2789,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         }
       }
     }
@@ -2721,8 +2812,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         }
       }
     },
@@ -2735,8 +2827,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         }
       }
     },
@@ -2752,8 +2845,9 @@
       "sdk-support": {
         "basic functionality": {
           "js": "0.10.0",
+          "android": "2.0.1",
           "ios": "2.0.0",
-          "android": "2.0.1"
+          "macos": "0.1.0"
         }
       }
     }


### PR DESCRIPTION
Added macOS SDK support information alongside the existing iOS SDK support information. (macOS SDK v0.2.1 [supports a few properties](https://github.com/mapbox/mapbox-gl-native/blob/master/platform/macos/CHANGELOG.md#021---july-19-2016) that iOS SDK v3.3.x does not.) Also clarified that, with respect to the iOS and macOS SDKs, this document is intended as a file format reference for style authors rather than a runtime styling reference.

/cc @jfirebaugh