### PR TITLE
iOS SDK v3.4.0, macOS SDK v0.3.0

### DIFF
--- a/docs/_generate/index.html
+++ b/docs/_generate/index.html
@@ -209,7 +209,6 @@ navigation:
           EPSG:3857 (or EPSG:900913) as a source of tiled data.
           The server url should contain a <code>"{bbox-epsg-3857}"</code>
           replacement token to supply the <code>bbox</code> parameter.
-          <em>(This feature is not yet supported by the Mapbox iOS SDK.)</em>
 {% highlight json%}
 "wms-imagery": {
   "type": "raster",
@@ -378,8 +377,8 @@ navigation:
               <td>clustering</td>
               <td class='center'>&gt;= 0.14.0</td>
               <td class='center'>&gt;= 4.2.0</td>
-              <td class='center'>Not yet supported</td>
-              <td class='center'>Not yet supported</td>
+              <td class='center'>&gt;= 3.4.0</td>
+              <td class='center'>&gt;= 0.3.0</td>
             </tr>
             </tbody>
           </table>

--- a/reference/v8.json
+++ b/reference/v8.json
@@ -786,7 +786,9 @@
         },
         "`auto` value": {
           "js": "0.25.0",
-          "android": "4.2.0"
+          "android": "4.2.0",
+          "ios": "3.4.0",
+          "macos": "0.3.0"
         }
       }
     },
@@ -837,6 +839,7 @@
         "basic functionality": {
           "js": "0.21.0",
           "android": "4.2.0",
+          "ios": "3.4.0",
           "macos": "0.2.1"
         }
       }
@@ -870,6 +873,7 @@
         "basic functionality": {
           "js": "0.21.0",
           "android": "4.2.0",
+          "ios": "3.4.0",
           "macos": "0.2.1"
         }
       }
@@ -1008,11 +1012,14 @@
         "basic functionality": {
           "js": "0.21.0",
           "android": "4.2.0",
+          "ios": "3.4.0",
           "macos": "0.2.1"
         },
         "`auto` value": {
           "js": "0.25.0",
-          "android": "4.2.0"
+          "android": "4.2.0",
+          "ios": "3.4.0",
+          "macos": "0.3.0"
         }
       }
     },
@@ -1045,7 +1052,9 @@
         },
         "`auto` value": {
           "js": "0.25.0",
-          "android": "4.2.0"
+          "android": "4.2.0",
+          "ios": "3.4.0",
+          "macos": "0.3.0"
         }
       }
     },
@@ -2339,6 +2348,7 @@
         "basic functionality": {
           "js": "0.21.0",
           "android": "4.2.0",
+          "ios": "3.4.0",
           "macos": "0.2.1"
         }
       }


### PR DESCRIPTION
Updated SDK compatibility tables for iOS SDK v3.4.0 and macOS SDK v0.3.0 based on their respective changelogs.

/cc @friedbunny @lucaswoj