### PR TITLE
Add source-canvas documentation

### DIFF
--- a/docs/_generate/index.html
+++ b/docs/_generate/index.html
@@ -543,9 +543,9 @@ navigation:
             <tr>
               <td>basic functionality</td>
               <td>&gt;= 0.32.0</td>
-              <td><a href="https://github.com/mapbox/mapbox-gl-native/issues/7823">Not yet supported</a></td>
-              <td><a href="https://github.com/mapbox/mapbox-gl-native/issues/7823">Not yet supported</a></td>
-              <td><a href="https://github.com/mapbox/mapbox-gl-native/issues/7823">Not yet supported</a></td>
+              <td>Not supported</td>
+              <td>Not supported</td>
+              <td>Not supported</td>
             </tr>
             </tbody>
           </table>

--- a/docs/_generate/index.html
+++ b/docs/_generate/index.html
@@ -34,6 +34,7 @@ navigation:
     - title: GeoJSON
     - title: Image
     - title: Video
+    - title: Canvas
   - title: Sprite
   - title: Glyphs
   - title: Transition
@@ -157,7 +158,7 @@ navigation:
     </div>
 
 
-    <% var source_types = ['vector', 'raster', 'geojson', 'image', 'video']; %>
+    <% var source_types = ['vector', 'raster', 'geojson', 'image', 'video', 'canvas']; %>
 
     <div class='pad2 prose'>
       <a id='sources' class='anchor'></a>
@@ -484,6 +485,67 @@ navigation:
               <td><a href="https://github.com/mapbox/mapbox-gl-native/issues/601">Not yet supported</a></td>
               <td><a href="https://github.com/mapbox/mapbox-gl-native/issues/601">Not yet supported</a></td>
               <td><a href="https://github.com/mapbox/mapbox-gl-native/issues/601">Not yet supported</a></td>
+            </tr>
+            </tbody>
+          </table>
+        </div>
+        <div id='sources-canvas' class='pad2 keyline-bottom'>
+          <h3 class='space-bottom1'><a href='#sources-canvas' title='link to canvas'>canvas</a></h3>
+          <p>
+            A canvas source. The <code>"canvas"</code> value is the ID of the canvas element in the document.
+          </p>
+          <p>
+            The <code>"coordinates"</code> array contains <code>[longitude, latitude]</code> pairs for the video
+            corners listed in clockwise order: top left, top right, bottom right, bottom left.
+          </p>
+          <p>
+            If an HTML document contains a canvas such as this:
+          </p>
+          <div class='space-bottom1 clearfix'>
+{% highlight html%}
+<canvas id="mycanvas" width="400" height="300" style="display: none;"></canvas>
+{% endhighlight %}
+          </div>
+          <p>
+            the corresponding canvas source would be specified as follows:
+          </p>
+          <div>
+{% highlight json %}
+"canvas": {
+  "type": "canvas",
+  "canvas": "mycanvas",
+  "coordinates": [
+     [-122.51596391201019, 37.56238816766053],
+     [-122.51467645168304, 37.56410183312965],
+     [-122.51309394836426, 37.563391708549425],
+     [-122.51423120498657, 37.56161849366671]
+  ]
+}
+{% endhighlight %}
+          </div>
+          <div class='space-bottom1 clearfix'>
+            <% _(ref.source_canvas).each(function(prop, name) { %>
+              <%  if (name === '*' || name === 'type') return %>
+              <%= item({prop: prop, id: "sources-canvas-" + name, name: name}) %>
+            <% }); %>
+          </div>
+          <table class="micro">
+            <thead>
+            <tr class='fill-light'>
+              <th>SDK Support</th>
+              <td class='center'>Mapbox GL JS</td>
+              <td class='center'>Android SDK</td>
+              <td class='center'>iOS SDK</td>
+              <td class='center'>macOS SDK</td>
+            </tr>
+            </thead>
+            <tbody>
+            <tr>
+              <td>basic functionality</td>
+              <td>&gt;= 0.32.0</td>
+              <td><a href="https://github.com/mapbox/mapbox-gl-native/issues/7823">Not yet supported</a></td>
+              <td><a href="https://github.com/mapbox/mapbox-gl-native/issues/7823">Not yet supported</a></td>
+              <td><a href="https://github.com/mapbox/mapbox-gl-native/issues/7823">Not yet supported</a></td>
             </tr>
             </tbody>
           </table>


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-gl-style-spec/issues/659.

![image](https://cloud.githubusercontent.com/assets/3170312/22229968/d9c59bca-e18f-11e6-9aaf-de19c046e858.png)
