### PR TITLE
Remove support for implicitly-categorical functions

### DIFF
--- a/docs/_generate/index.html
+++ b/docs/_generate/index.html
@@ -850,11 +850,11 @@ navigation:
                 <dt><var>identity</var></dt>
                 <dd>functions return their input as their output.</dd>
                 <dt><var>exponential</var></dt>
-                <dd>functions generate an output by interpolating between stops just less than and just greater than the function input. The domain must be numeric. This is the default for numeric domain, <span class='icon smooth-ramp quiet micro space-right indivne' title='continuous'></span> range functions.</dd>
+                <dd>functions generate an output by interpolating between stops just less than and just greater than the function input. The domain must be numeric. This is the default for properties marked with <span class='icon smooth-ramp quiet micro space-right indivne' title='continuous'></span>, the "exponential" symbol.</dd>
                 <dt><var>interval</var></dt>
-                <dd>functions return the output value of the stop just less than the function input. The domain must be numeric. This is the default for numeric domain, <span class='icon step-ramp quiet micro space-right indivne' title='discrete'></span> range functions.</dd>
+                <dd>functions return the output value of the stop just less than the function input. The domain must be numeric. This is the default for properties marked with <span class='icon step-ramp quiet micro space-right indivne' title='discrete'></span>, the "interval" symbol.</dd>
                 <dt><var>categorical</var></dt>
-                <dd>functions return the output value of the stop equal to the function input. This is the default for string domain functions.</dd>
+                <dd>functions return the output value of the stop equal to the function input.</dd>
               </dl>
             </div>
             <div class="col12 clearfix pad0y pad2x space-bottom2">

--- a/lib/function/index.js
+++ b/lib/function/index.js
@@ -20,8 +20,7 @@ function createFunction(parameters, defaultType) {
         var zoomAndFeatureDependent = parameters.stops && typeof parameters.stops[0][0] === 'object';
         var featureDependent = zoomAndFeatureDependent || parameters.property !== undefined;
         var zoomDependent = zoomAndFeatureDependent || !featureDependent;
-        var inputType = parameters.stops && typeof (zoomAndFeatureDependent ? parameters.stops[0][0].property : parameters.stops[0][0]);
-        var type = parameters.type || defaultType || (inputType === 'string' ? 'categorical' : 'exponential');
+        var type = parameters.type || defaultType || 'exponential';
 
         var innerFun;
         if (type === 'exponential') {

--- a/lib/validate/validate_function.js
+++ b/lib/validate/validate_function.js
@@ -149,9 +149,6 @@ module.exports = function validateFunction(options) {
 
         if (!stopKeyType) {
             stopKeyType = type;
-            if (!functionType && type === 'string') {
-                functionType = 'categorical';
-            }
         } else if (type !== stopKeyType) {
             return [new ValidationError(options.key, options.value, '%s stop domain type must match previous stop domain type %s', type, stopKeyType)];
         }
@@ -161,7 +158,11 @@ module.exports = function validateFunction(options) {
         }
 
         if (type !== 'number' && functionType !== 'categorical') {
-            return [new ValidationError(options.key, options.value, 'number expected, %s found', type)];
+            var message = 'number expected, %s found';
+            if (functionValueSpec['property-function'] && functionType === undefined) {
+                message += '\nIf you intended to use a categorical function, specify `"type": "categorical"`.';
+            }
+            return [new ValidationError(options.key, options.value, message, type)];
         }
 
         if (functionType === 'categorical' && type === 'number' && (!isFinite(value) || Math.floor(value) !== value)) {

--- a/test/fixture/functions.input.json
+++ b/test/fixture/functions.input.json
@@ -313,7 +313,7 @@
       }
     },
     {
-      "id": "invalid object-keyed string stop for zoom function",
+      "id": "invalid categorical function - missing type and property",
       "type": "fill",
       "source": "source",
       "source-layer": "layer",
@@ -329,7 +329,7 @@
       }
     },
     {
-      "id": "valid object-keyed string stop for property function",
+      "id": "invalid categorical function - missing type",
       "type": "fill",
       "source": "source",
       "source-layer": "layer",
@@ -338,7 +338,7 @@
           "property": "mapbox",
           "stops": [
             [
-              "good",
+              "bad",
               "#fff"
             ]
           ]
@@ -346,17 +346,35 @@
       }
     },
     {
-      "id": "invalid use of property function",
-      "type": "background",
+      "id": "invalid categorical function - missing property",
+      "type": "fill",
       "source": "source",
       "source-layer": "layer",
       "paint": {
-        "background-color": {
+        "fill-color": {
+          "type": "categorical",
+          "stops": [
+            [
+              "bad",
+              "#fff"
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "valid categorical function",
+      "type": "fill",
+      "source": "source",
+      "source-layer": "layer",
+      "paint": {
+        "fill-color": {
+          "type": "categorical",
           "property": "mapbox",
           "stops": [
             [
               "good",
-              "green"
+              "#fff"
             ]
           ]
         }
@@ -382,40 +400,6 @@
         "background-color": {
           "type": "identity",
           "stops": []
-        }
-      }
-    },
-    {
-      "id": "valid implicitly categorical property function",
-      "type": "fill",
-      "source": "source",
-      "source-layer": "layer",
-      "paint": {
-        "fill-color": {
-          "property": "mapbox",
-          "stops": [
-            [
-              "good",
-              "green"
-            ]
-          ]
-        }
-      }
-    },
-    {
-      "id": "valid implicitly categorical zoom-and-property function",
-      "type": "fill",
-      "source": "source",
-      "source-layer": "layer",
-      "paint": {
-        "fill-color": {
-          "property": "mapbox",
-          "stops": [
-            [
-              {"zoom": 0, "value": "good"},
-              "green"
-            ]
-          ]
         }
       }
     },
@@ -624,23 +608,6 @@
                 "value": "v"
               },
               true
-            ]
-          ]
-        }
-      }
-    },
-    {
-      "id": "invalid categorical function missing property",
-      "type": "fill",
-      "source": "source",
-      "source-layer": "layer",
-      "paint": {
-        "fill-color": {
-          "type": "categorical",
-          "stops": [
-            [
-              "good",
-              "#fff"
             ]
           ]
         }

--- a/test/fixture/functions.output.json
+++ b/test/fixture/functions.output.json
@@ -28,8 +28,8 @@
     "line": 75
   },
   {
-    "message": "layers[6].paint.line-width: \"property\" property is required",
-    "line": 86
+    "message": "layers[6].paint.line-width.stops[0][0]: number expected, string found",
+    "line": 89
   },
   {
     "message": "layers[7].paint.line-width.stops[0][1]: number expected, string found",
@@ -72,78 +72,82 @@
     "line": 305
   },
   {
-    "message": "layers[17].paint.fill-color: \"property\" property is required",
-    "line": 321
+    "message": "layers[17].paint.fill-color.stops[0][0]: number expected, string found\nIf you intended to use a categorical function, specify `\"type\": \"categorical\"`.",
+    "line": 324
   },
   {
-    "message": "layers[32].paint.fill-color.stops[0][0]: property value must be a number or string"
+    "message": "layers[18].paint.fill-color.stops[0][0]: number expected, string found\nIf you intended to use a categorical function, specify `\"type\": \"categorical\"`.",
+    "line": 341
   },
   {
-    "message": "layers[19].paint.background-color: property functions not supported",
+    "message": "layers[31].paint.fill-color.stops[0][0]: property value must be a number or string"
+  },
+  {
+    "message": "layers[19].paint.fill-color: \"property\" property is required",
     "line": 354
   },
   {
-    "message": "layers[21].paint.background-color.stops: identity function may not have a \"stops\" property",
-    "line": 384
+    "message": "layers[22].paint.background-color.stops: identity function may not have a \"stops\" property",
+    "line": 402
   },
   {
-    "message": "layers[24].paint.fill-color.stops[1][0]: number stop domain type must match previous stop domain type string",
-    "line": 437
+    "message": "layers[23].paint.fill-color.stops[1][0]: number stop domain type must match previous stop domain type string",
+    "line": 421
   },
   {
-    "message": "layers[25].paint.fill-color.stops[1][0].value: number stop domain type must match previous stop domain type string",
-    "line": 459
+    "message": "layers[24].paint.fill-color.stops[1][0].value: number stop domain type must match previous stop domain type string",
+    "line": 443
   },
   {
-    "message": "layers[26].paint.fill-color.stops[0][0]: number expected, string found",
-    "line": 477
+    "message": "layers[25].paint.fill-color.stops[0][0]: number expected, string found",
+    "line": 461
   },
   {
-    "message": "layers[27].paint.fill-color.stops[0][0].value: number expected, string found",
-    "line": 495
+    "message": "layers[26].paint.fill-color.stops[0][0].value: number expected, string found",
+    "line": 479
   },
   {
-    "message": "layers[28].paint.fill-color.stops[0][0]: number expected, string found",
-    "line": 513
+    "message": "layers[27].paint.fill-color.stops[0][0]: number expected, string found",
+    "line": 497
   },
   {
-    "message": "layers[29].paint.fill-color.stops[0][0].value: number expected, string found",
-    "line": 531
+    "message": "layers[28].paint.fill-color.stops[0][0].value: number expected, string found",
+    "line": 515
+  },
+  {
+    "message": "layers[29].paint.fill-color.stops[0][0]: property value must be a number or string",
+    "line": 533
   },
   {
     "message": "layers[30].paint.fill-color.stops[0][0]: property value must be a number or string",
-    "line": 549
+    "line": 551
   },
   {
-    "message": "layers[31].paint.fill-color.stops[0][0]: property value must be a number or string",
-    "line": 567
+    "message": "layers[32].paint.fill-antialias: exponential functions not supported",
+    "line": 582
   },
   {
-    "message": "layers[33].paint.fill-antialias: exponential functions not supported",
-    "line": 598
+    "message": "layers[33].paint.fill-antialias: \"property\" property is required",
+    "line": 603
   },
   {
-    "message": "layers[34].paint.fill-antialias: \"property\" property is required",
-    "line": 619
+    "message": "layers[33].paint.fill-antialias.stops[0][0].value: number expected, string found",
+    "line": 608
   },
   {
-    "message": "layers[35].paint.fill-color: \"property\" property is required",
-    "line": 638
+    "message": "layers[34].paint.fill-opacity.stops[2][0]: stop domain values must be unique",
+    "line": 635
   },
   {
-    "message": "layers[36].paint.fill-opacity.stops[2][0]: stop domain values must be unique",
-    "line": 668
+    "message": "layers[35].paint.fill-opacity.stops[0][0]: integer expected, found 0.33",
+    "line": 653
   },
   {
-    "message": "layers[37].paint.fill-opacity.stops[0][0]: integer expected, found 0.33",
-    "line": 686
+    "message": "layers[36].paint.fill-opacity.stops[1][0].value: stop domain values must appear in ascending order",
+    "line": 679
   },
   {
-    "message": "layers[38].paint.fill-opacity.stops[1][0].value: stop domain values must appear in ascending order",
-    "line": 712
-  },
-  {
-    "message": "layers[39].paint.fill-opacity.stops[1]: stop zoom values must appear in ascending order",
-    "line": 738
+    "message": "layers[37].paint.fill-opacity.stops[1]: stop zoom values must appear in ascending order",
+    "line": 705
   }
 ]

--- a/test/function.js
+++ b/test/function.js
@@ -45,7 +45,7 @@ test('function types', function(t) {
 
     t.test('exponential', function(t) {
 
-        t.test('is the default type for numeric inputs', function(t) {
+        t.test('is the default', function(t) {
             var f = MapboxGLFunction({
                 stops: [[1, 2], [3, 6]],
                 base: 2
@@ -363,16 +363,6 @@ test('function types', function(t) {
     });
 
     t.test('categorical', function(t) {
-
-        t.test('is the default type for string inputs', function(t) {
-            var f = MapboxGLFunction({
-                stops: [['umpteen', 42]]
-            });
-
-            t.equal(f('umpteen'), 42);
-
-            t.end();
-        });
 
         t.test('one element', function(t) {
             var f = MapboxGLFunction({


### PR DESCRIPTION
This turned out to add significant complexity to the gl-native implementation, and never took effect in gl-js due to a bug (https://github.com/mapbox/mapbox-gl-js/issues/3717). Removing it due to the complexity it would add to gl-native and other implementations, and the following additional rationales:

* As a general principle: explicit is better than implicit.
* Most users will not be constructing functions by hand anyway. For those that do:
* Requiring `"type": "categorical"` is not an undue burden, especially when coupled with a hinting mechanism in the validator as implemented here.
* Implicitly supplying `"type": "categorical"` for string domain values introduces a potentially surprising difference between `"stops": [["1", 1], ["2", 2]]` and `"stops": [[1, 1], [2, 2]]`.

Closes https://github.com/mapbox/mapbox-gl-js/issues/3717
Closes https://github.com/mapbox/mapbox-gl-js/issues/3948